### PR TITLE
매장 조회 시, 페이징 및 정렬 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,41 +1,47 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.0'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/oheat/common/QueryDslConfig.java
+++ b/src/main/java/com/oheat/common/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.oheat.common;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/oheat/food/controller/ShopController.java
+++ b/src/main/java/com/oheat/food/controller/ShopController.java
@@ -4,8 +4,9 @@ import com.oheat.food.dto.ShopFindByCategoryResponse;
 import com.oheat.food.dto.ShopSaveRequest;
 import com.oheat.food.dto.ShopUpdateRequest;
 import com.oheat.food.service.ShopService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -32,10 +33,10 @@ public class ShopController {
     }
 
     @GetMapping
-    public List<ShopFindByCategoryResponse> findShopByCategory(@RequestParam String category) {
-        return shopService.findShopByCategory(category).stream()
-            .map(ShopFindByCategoryResponse::from)
-            .toList();
+    public Page<ShopFindByCategoryResponse> findShopByCategory(
+        @RequestParam String category, Pageable pageable) {
+        return shopService.findShopByCategory(category, pageable)
+            .map(ShopFindByCategoryResponse::from);
     }
 
     @PutMapping

--- a/src/main/java/com/oheat/food/dto/ShopFindByCategoryResponse.java
+++ b/src/main/java/com/oheat/food/dto/ShopFindByCategoryResponse.java
@@ -15,6 +15,7 @@ public class ShopFindByCategoryResponse {
     private final String phone;
     private final String category;
     private final int minimumOrderAmount;
+    private final int deliveryFee;
 
     public static ShopFindByCategoryResponse from(ShopJpaEntity shopJpaEntity) {
         return ShopFindByCategoryResponse.builder()
@@ -23,6 +24,7 @@ public class ShopFindByCategoryResponse {
             .phone(shopJpaEntity.getPhone())
             .category(shopJpaEntity.getCategory().getName())
             .minimumOrderAmount(shopJpaEntity.getMinimumOrderAmount())
+            .deliveryFee((shopJpaEntity.getDeliveryFee()))
             .build();
     }
 }

--- a/src/main/java/com/oheat/food/dto/ShopSaveRequest.java
+++ b/src/main/java/com/oheat/food/dto/ShopSaveRequest.java
@@ -15,6 +15,7 @@ public class ShopSaveRequest {
     private final String phone;
     private final String category;
     private final int minimumOrderAmount;
+    private final int deliveryFee;
 
     public ShopJpaEntity toEntity(CategoryJpaEntity category) {
         return ShopJpaEntity.builder()
@@ -22,6 +23,7 @@ public class ShopSaveRequest {
             .phone(this.phone)
             .category(category)
             .minimumOrderAmount(this.minimumOrderAmount)
+            .deliveryFee(this.deliveryFee)
             .build();
     }
 }

--- a/src/main/java/com/oheat/food/dto/ShopUpdateRequest.java
+++ b/src/main/java/com/oheat/food/dto/ShopUpdateRequest.java
@@ -14,4 +14,6 @@ public class ShopUpdateRequest {
     private final String phone;
     private final String category;
     private final int minimumOrderAmount;
+    private final int deliveryFee;
+
 }

--- a/src/main/java/com/oheat/food/entity/ShopJpaEntity.java
+++ b/src/main/java/com/oheat/food/entity/ShopJpaEntity.java
@@ -26,19 +26,20 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(exclude = {"phone", "category", "minimumOrderAmount", "menuSet", "menuGroups"},
-    callSuper = false)
+@EqualsAndHashCode(exclude = {"phone", "minimumOrderAmount", "deliveryFee", "category", "menuSet",
+    "menuGroups"}, callSuper = false)
 @Entity
 @Table(name = "shop")
 public class ShopJpaEntity extends BaseTimeEntity {
 
     @Builder
     public ShopJpaEntity(String name, String phone, CategoryJpaEntity category,
-        int minimumOrderAmount) {
+        int minimumOrderAmount, int deliveryFee) {
         this.name = name;
         this.phone = phone;
         this.category = category;
         this.minimumOrderAmount = minimumOrderAmount;
+        this.deliveryFee = deliveryFee;
     }
 
     @Id
@@ -51,12 +52,15 @@ public class ShopJpaEntity extends BaseTimeEntity {
     @Column(name = "phone")
     private String phone;
 
+    @Column(name = "minimum_order_amount", nullable = false)
+    private int minimumOrderAmount;
+
+    @Column(name = "delivery_fee", nullable = false)
+    private int deliveryFee;
+
     @ManyToOne
     @JoinColumn(name = "category", referencedColumnName = "name", nullable = false)
     private CategoryJpaEntity category;
-
-    @Column(name = "minimum_order_amount", nullable = false)
-    private int minimumOrderAmount;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "shop")
     private final Set<MenuJpaEntity> menuSet = new HashSet<>();
@@ -69,6 +73,7 @@ public class ShopJpaEntity extends BaseTimeEntity {
         this.phone = updateRequest.getPhone();
         this.category = category;
         this.minimumOrderAmount = updateRequest.getMinimumOrderAmount();
+        this.deliveryFee = updateRequest.getDeliveryFee();
     }
 
     public void addMenu(MenuJpaEntity menu) {

--- a/src/main/java/com/oheat/food/repository/OptionGroupRepository.java
+++ b/src/main/java/com/oheat/food/repository/OptionGroupRepository.java
@@ -1,5 +1,0 @@
-package com.oheat.food.repository;
-
-public interface OptionGroupRepository {
-
-}

--- a/src/main/java/com/oheat/food/repository/OptionGroupRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/OptionGroupRepositoryImpl.java
@@ -1,8 +1,0 @@
-package com.oheat.food.repository;
-
-import org.springframework.stereotype.Repository;
-
-@Repository
-public class OptionGroupRepositoryImpl implements OptionGroupRepository {
-
-}

--- a/src/main/java/com/oheat/food/repository/OptionRepository.java
+++ b/src/main/java/com/oheat/food/repository/OptionRepository.java
@@ -1,5 +1,0 @@
-package com.oheat.food.repository;
-
-public interface OptionRepository {
-
-}

--- a/src/main/java/com/oheat/food/repository/OptionRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/OptionRepositoryImpl.java
@@ -1,8 +1,0 @@
-package com.oheat.food.repository;
-
-import org.springframework.stereotype.Repository;
-
-@Repository
-public class OptionRepositoryImpl implements OptionRepository {
-
-}

--- a/src/main/java/com/oheat/food/repository/ShopCustomRepository.java
+++ b/src/main/java/com/oheat/food/repository/ShopCustomRepository.java
@@ -1,0 +1,11 @@
+package com.oheat.food.repository;
+
+import com.oheat.food.entity.CategoryJpaEntity;
+import com.oheat.food.entity.ShopJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ShopCustomRepository {
+
+    Page<ShopJpaEntity> findShopByCategory(CategoryJpaEntity category, Pageable pageable);
+}

--- a/src/main/java/com/oheat/food/repository/ShopCustomRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/ShopCustomRepositoryImpl.java
@@ -4,12 +4,16 @@ import static com.oheat.food.entity.QShopJpaEntity.shopJpaEntity;
 
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @RequiredArgsConstructor
 public class ShopCustomRepositoryImpl implements ShopCustomRepository {
@@ -19,9 +23,12 @@ public class ShopCustomRepositoryImpl implements ShopCustomRepository {
     @Override
     public Page<ShopJpaEntity> findShopByCategory(CategoryJpaEntity category, Pageable pageable) {
 
+        OrderSpecifier[] orders = createOrderSpecifier(pageable.getSort());
+
         List<ShopJpaEntity> content = jpaQueryFactory
             .selectFrom(shopJpaEntity)
             .where(shopJpaEntity.category.eq(category))
+            .orderBy(orders)
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
@@ -33,5 +40,21 @@ public class ShopCustomRepositoryImpl implements ShopCustomRepository {
             .fetchOne();
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    private OrderSpecifier[] createOrderSpecifier(Sort sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        for (Sort.Order order : sort) {
+            Order direction = order.getDirection().isDescending() ? Order.DESC : Order.ASC;
+            String property = order.getProperty();
+            switch (property) {
+                case "id":
+                    orders.add(new OrderSpecifier(direction, shopJpaEntity.id));
+                case "minimumOrderAmount":
+                    orders.add(new OrderSpecifier(direction, shopJpaEntity.minimumOrderAmount));
+            }
+        }
+        return orders.toArray(OrderSpecifier[]::new);
     }
 }

--- a/src/main/java/com/oheat/food/repository/ShopCustomRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/ShopCustomRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.oheat.food.repository;
+
+import static com.oheat.food.entity.QShopJpaEntity.shopJpaEntity;
+
+import com.oheat.food.entity.CategoryJpaEntity;
+import com.oheat.food.entity.ShopJpaEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class ShopCustomRepositoryImpl implements ShopCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<ShopJpaEntity> findShopByCategory(CategoryJpaEntity category, Pageable pageable) {
+
+        List<ShopJpaEntity> content = jpaQueryFactory
+            .selectFrom(shopJpaEntity)
+            .where(shopJpaEntity.category.eq(category))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long total = jpaQueryFactory
+            .select(shopJpaEntity.count())
+            .from(shopJpaEntity)
+            .where(shopJpaEntity.category.eq(category))
+            .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/oheat/food/repository/ShopCustomRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/ShopCustomRepositoryImpl.java
@@ -53,6 +53,8 @@ public class ShopCustomRepositoryImpl implements ShopCustomRepository {
                     orders.add(new OrderSpecifier(direction, shopJpaEntity.id));
                 case "minimumOrderAmount":
                     orders.add(new OrderSpecifier(direction, shopJpaEntity.minimumOrderAmount));
+                case "deliveryFee":
+                    orders.add(new OrderSpecifier(direction, shopJpaEntity.deliveryFee));
             }
         }
         return orders.toArray(OrderSpecifier[]::new);

--- a/src/main/java/com/oheat/food/repository/ShopJpaRepository.java
+++ b/src/main/java/com/oheat/food/repository/ShopJpaRepository.java
@@ -1,16 +1,13 @@
 package com.oheat.food.repository;
 
-import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ShopJpaRepository extends JpaRepository<ShopJpaEntity, Long> {
+public interface ShopJpaRepository extends JpaRepository<ShopJpaEntity, Long>,
+    ShopCustomRepository {
 
     Optional<ShopJpaEntity> findByName(String name);
-
-    List<ShopJpaEntity> findByCategory(CategoryJpaEntity category);
 
     void deleteByName(String name);
 }

--- a/src/main/java/com/oheat/food/repository/ShopRepository.java
+++ b/src/main/java/com/oheat/food/repository/ShopRepository.java
@@ -2,8 +2,9 @@ package com.oheat.food.repository;
 
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ShopRepository {
 
@@ -13,7 +14,7 @@ public interface ShopRepository {
 
     Optional<ShopJpaEntity> findByName(String name);
 
-    List<ShopJpaEntity> findByCategory(CategoryJpaEntity category);
+    Page<ShopJpaEntity> findByCategory(CategoryJpaEntity category, Pageable pageable);
 
     void deleteById(Long shopId);
 }

--- a/src/main/java/com/oheat/food/repository/ShopRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/ShopRepositoryImpl.java
@@ -2,9 +2,10 @@ package com.oheat.food.repository;
 
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -29,8 +30,8 @@ public class ShopRepositoryImpl implements ShopRepository {
     }
 
     @Override
-    public List<ShopJpaEntity> findByCategory(CategoryJpaEntity category) {
-        return shopJpaRepository.findByCategory(category);
+    public Page<ShopJpaEntity> findByCategory(CategoryJpaEntity category, Pageable pageable) {
+        return shopJpaRepository.findShopByCategory(category, pageable);
     }
 
     @Override

--- a/src/main/java/com/oheat/food/service/ShopService.java
+++ b/src/main/java/com/oheat/food/service/ShopService.java
@@ -10,8 +10,9 @@ import com.oheat.food.exception.ShopNotExistsException;
 import com.oheat.food.repository.CategoryRepository;
 import com.oheat.food.repository.ShopRepository;
 import jakarta.transaction.Transactional;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -34,11 +35,11 @@ public class ShopService {
         shopRepository.save(saveRequest.toEntity(category));
     }
 
-    public List<ShopJpaEntity> findShopByCategory(String categoryName) {
+    public Page<ShopJpaEntity> findShopByCategory(String categoryName, Pageable pageable) {
         CategoryJpaEntity category = categoryRepository.findByName(categoryName)
             .orElseThrow(CategoryNotExistsException::new);
 
-        return shopRepository.findByCategory(category);
+        return shopRepository.findByCategory(category, pageable);
     }
 
     @Transactional

--- a/src/test/java/com/oheat/common/TestConfig.java
+++ b/src/test/java/com/oheat/common/TestConfig.java
@@ -1,0 +1,19 @@
+package com.oheat.common;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/oheat/food/fake/MemoryShopRepository.java
+++ b/src/test/java/com/oheat/food/fake/MemoryShopRepository.java
@@ -8,6 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 @Getter
 public class MemoryShopRepository implements ShopRepository {
@@ -33,10 +36,11 @@ public class MemoryShopRepository implements ShopRepository {
     }
 
     @Override
-    public List<ShopJpaEntity> findByCategory(CategoryJpaEntity category) {
-        return shops.values().stream()
+    public Page<ShopJpaEntity> findByCategory(CategoryJpaEntity category, Pageable pageable) {
+        List<ShopJpaEntity> shopList = shops.values().stream()
             .filter(shop -> shop.getCategory().equals(category))
             .toList();
+        return new PageImpl<>(shopList);
     }
 
     @Override

--- a/src/test/java/com/oheat/food/jpaTest/CategoryRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/CategoryRepositoryTest.java
@@ -2,6 +2,7 @@ package com.oheat.food.jpaTest;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.oheat.common.TestConfig;
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.repository.CategoryJpaRepository;
 import java.util.List;
@@ -10,8 +11,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
+@Import(TestConfig.class)
 @DataJpaTest
 public class CategoryRepositoryTest {
 

--- a/src/test/java/com/oheat/food/jpaTest/MenuGroupRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/MenuGroupRepositoryTest.java
@@ -2,6 +2,7 @@ package com.oheat.food.jpaTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.oheat.common.TestConfig;
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.MenuGroupJpaEntity;
 import com.oheat.food.entity.MenuGroupMappingJpaEntity;
@@ -21,8 +22,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
+@Import(TestConfig.class)
 @DataJpaTest
 public class MenuGroupRepositoryTest {
 

--- a/src/test/java/com/oheat/food/jpaTest/MenuRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/MenuRepositoryTest.java
@@ -12,8 +12,6 @@ import com.oheat.food.entity.OptionJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.repository.CategoryJpaRepository;
 import com.oheat.food.repository.MenuJpaRepository;
-import com.oheat.food.repository.OptionGroupJpaRepository;
-import com.oheat.food.repository.OptionJpaRepository;
 import com.oheat.food.repository.ShopJpaRepository;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -98,53 +96,6 @@ public class MenuRepositoryTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 메뉴에 옵션 그룹을 추가하면 실패")
-    void givenOptionGroupWithWrongMenuId_whenAddNewOptionGroup_thenFail() {
-        CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
-        MenuJpaEntity menu = MenuJpaEntity.builder().name("황올").shop(shop).build();
-
-        categoryJpaRepository.save(category);
-        shopJpaRepository.save(shop);
-        menuJpaRepository.save(menu);
-        menuJpaRepository.deleteAll();
-        entityManager.flush();
-
-        Assertions.assertThrows(DataIntegrityViolationException.class, () -> {
-            optionGroupJpaRepository.save(OptionGroupJpaEntity.builder()
-                .name("부분육 선택")
-                .menu(menu)
-                .build());
-        });
-        entityManager.clear();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 옵션 그룹에 옵션을 추가하면 실패")
-    void givenOptionWithWrongOptionGroupId_whenAddNewOption_thenFail() {
-        CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
-        MenuJpaEntity menu = MenuJpaEntity.builder().name("황올").shop(shop).build();
-        OptionGroupJpaEntity optionGroup = OptionGroupJpaEntity.builder()
-            .name("부분육 선택").menu(menu).build();
-
-        categoryJpaRepository.save(category);
-        shopJpaRepository.save(shop);
-        menuJpaRepository.save(menu);
-        optionGroupJpaRepository.save(optionGroup);
-        optionGroupJpaRepository.deleteAll();
-        entityManager.flush();
-
-        Assertions.assertThrows(DataIntegrityViolationException.class, () -> {
-            optionJpaRepository.save(OptionJpaEntity.builder()
-                .name("순살")
-                .optionGroup(optionGroup)
-                .build());
-        });
-        entityManager.clear();
-    }
-
-    @Test
     @DisplayName("카테고리, 매장, 메뉴, 옵션 그룹, 옵션을 차례로 알맞게 저장하면 모두 저장 성공")
     void givenShopAndMenuAndOptionGroupAndOption_whenAddNewMenu_thenSuccess() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
@@ -164,10 +115,13 @@ public class MenuRepositoryTest {
             menu.addOptionGroup(optionGroup);
             menuJpaRepository.save(menu);
         });
+        entityManager.clear();
 
         // 옵션 그룹과 옵션 저장 확인
-        OptionGroupJpaEntity optionGroupResult = optionGroupJpaRepository.findById(1L).get();
-        OptionJpaEntity optionResult = optionJpaRepository.findById(1L).get();
+        OptionGroupJpaEntity optionGroupResult = menuJpaRepository.findById(1L).get()
+            .getOptionGroups().getFirst();
+        OptionJpaEntity optionResult = optionGroupResult.getOptions().getFirst();
+
         assertThat(optionGroupResult.getName()).isEqualTo("부분육 선택");
         assertThat(optionResult.getName()).isEqualTo("순살");
     }

--- a/src/test/java/com/oheat/food/jpaTest/MenuRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/MenuRepositoryTest.java
@@ -2,6 +2,7 @@ package com.oheat.food.jpaTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.oheat.common.TestConfig;
 import com.oheat.food.dto.MenuUpdateRequest;
 import com.oheat.food.dto.OptionGroupUpdateRequest;
 import com.oheat.food.dto.OptionUpdateRequest;
@@ -21,8 +22,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
+@Import(TestConfig.class)
 @DataJpaTest
 public class MenuRepositoryTest {
 

--- a/src/test/java/com/oheat/food/jpaTest/OptionGroupJpaRepository.java
+++ b/src/test/java/com/oheat/food/jpaTest/OptionGroupJpaRepository.java
@@ -1,4 +1,4 @@
-package com.oheat.food.repository;
+package com.oheat.food.jpaTest;
 
 import com.oheat.food.entity.OptionGroupJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/test/java/com/oheat/food/jpaTest/OptionJpaRepository.java
+++ b/src/test/java/com/oheat/food/jpaTest/OptionJpaRepository.java
@@ -1,4 +1,4 @@
-package com.oheat.food.repository;
+package com.oheat.food.jpaTest;
 
 import com.oheat.food.entity.OptionJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/test/java/com/oheat/food/jpaTest/ShopRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/ShopRepositoryTest.java
@@ -165,10 +165,26 @@ public class ShopRepositoryTest {
         assertThat(result.get(2).getId()).isEqualTo(1L);
     }
 
-    @Disabled
     @Test
     @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 배달팁 낮은 순이면, 배달팁 오름차순으로 조회")
     void whenSortByDeliveryTip_thenDeliveryTipAscendingOrder() {
+        CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
+        categoryJpaRepository.save(category);
+
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 1호점").category(category).deliveryFee(2000).build());
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 2호점").category(category).deliveryFee(1000).build());
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 3호점").category(category).deliveryFee(5000).build());
+
+        PageRequest page0 = PageRequest.of(0, 5, Sort.by("deliveryFee").ascending());
+        List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
+            .getContent();
+
+        assertThat(result.get(0).getId()).isEqualTo(2L);
+        assertThat(result.get(1).getId()).isEqualTo(1L);
+        assertThat(result.get(2).getId()).isEqualTo(3L);
     }
 
     @Test
@@ -191,6 +207,29 @@ public class ShopRepositoryTest {
         assertThat(result.get(0).getId()).isEqualTo(2L);
         assertThat(result.get(1).getId()).isEqualTo(1L);
         assertThat(result.get(2).getId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("정렬 기준이 최소주문 금액 낮은 순이면, 같은 금액일 때 id 내림차순(최신 등록순)으로 정렬")
+    void whenSortByMinimumOrderAmountAndId_thenMinimumOrderAmountAscendingAndIdDescendingOrder() {
+        CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
+        categoryJpaRepository.save(category);
+
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 1호점").category(category).minimumOrderAmount(1000).build());
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 2호점").category(category).minimumOrderAmount(3000).build());
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 3호점").category(category).minimumOrderAmount(1000).build());
+
+        PageRequest page0 = PageRequest.of(0, 5, Sort.by("minimumOrderAmount").ascending()
+            .and(Sort.by("id").descending()));
+        List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
+            .getContent();
+
+        assertThat(result.get(0).getId()).isEqualTo(3L);
+        assertThat(result.get(1).getId()).isEqualTo(1L);
+        assertThat(result.get(2).getId()).isEqualTo(2L);
     }
 
     @Disabled

--- a/src/test/java/com/oheat/food/jpaTest/ShopRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/ShopRepositoryTest.java
@@ -9,6 +9,7 @@ import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.repository.CategoryJpaRepository;
 import com.oheat.food.repository.ShopJpaRepository;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -97,5 +98,53 @@ public class ShopRepositoryTest {
         List<ShopJpaEntity> result = shopJpaRepository.findByCategory(category);
 
         assertThat(result.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("치킨 매장이 7개이고 5개 단위로 페이징할 때, 조회 결과는 0번 페이지는 5개, 1번 페이지는 2개이다")
+    void givenSevenShops_whenFindShopByCategory_thenPage0Return5AndPage1Return2() {
+
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 기본순이면, 최근 등록 순으로 조회")
+    void whenSortByDefault_thenRecentRegistrationOrder() {
+
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 배달팁 낮은 순이면, 배달팁 오름차순으로 조회")
+    void whenSortByDeliveryTip_thenDeliveryTipAscendingOrder() {
+
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 최소주문 금액 낮은 순이면, 최소주문 금액 오름차순으로 조회")
+    void whenSortByMinimumOrderAmount_thenMinimumOrderAmountAscendingOrder() {
+
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 가까운 순이면, 내 위치에서의 거리 오름차순으로 조회")
+    void whenSortByNearestOrder_thenDistanceInMyLocationAscendingOrder() {
+
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 주문 많은 순이면, 누적 주문 수 내림차순으로 조회")
+    void whenSortByOrderAmount_thenOrderAmountDescendingOrder() {
+
+    }
+
+    @Disabled
+    @Test
+    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 별점 높은 순이면, 별점 내림차순으로 조회")
+    void whenSortByReviewScore_thenReviewScoreDescendingOrder() {
+
     }
 }

--- a/src/test/java/com/oheat/food/serviceTest/ShopCRUDTest.java
+++ b/src/test/java/com/oheat/food/serviceTest/ShopCRUDTest.java
@@ -16,12 +16,12 @@ import com.oheat.food.repository.CategoryRepository;
 import com.oheat.food.repository.ShopRepository;
 import com.oheat.food.service.CategoryService;
 import com.oheat.food.service.ShopService;
-import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 
 public class ShopCRUDTest {
 
@@ -112,9 +112,9 @@ public class ShopCRUDTest {
                 .build());
         }
 
-        List<ShopJpaEntity> result = shopService.findShopByCategory("치킨");
+        Page<ShopJpaEntity> result = shopService.findShopByCategory("치킨", null);
 
-        Assertions.assertThat(result.size()).isEqualTo(3);
+        Assertions.assertThat(result.getContent().size()).isEqualTo(3);
     }
 
     @Disabled

--- a/src/test/java/com/oheat/food/serviceTest/ShopCRUDTest.java
+++ b/src/test/java/com/oheat/food/serviceTest/ShopCRUDTest.java
@@ -126,48 +126,6 @@ public class ShopCRUDTest {
 
     @Disabled
     @Test
-    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 기본순이면, 최근 등록 순으로 조회")
-    void whenSortByDefault_thenRecentRegistrationOrder() {
-
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 배달팁 낮은 순이면, 배달팁 오름차순으로 조회")
-    void whenSortByDeliveryTip_thenDeliveryTipAscendingOrder() {
-
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 최소주문 금액 낮은 순이면, 최소주문 금액 오름차순으로 조회")
-    void whenSortByMinimumOrderAmount_thenMinimumOrderAmountAscendingOrder() {
-
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 가까운 순이면, 내 위치에서의 거리 오름차순으로 조회")
-    void whenSortByNearestOrder_thenDistanceInMyLocationAscendingOrder() {
-
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 주문 많은 순이면, 누적 주문 수 내림차순으로 조회")
-    void whenSortByOrderAmount_thenOrderAmountDescendingOrder() {
-
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 별점 높은 순이면, 별점 내림차순으로 조회")
-    void whenSortByReviewScore_thenReviewScoreDescendingOrder() {
-
-    }
-
-    @Disabled
-    @Test
     @DisplayName("매장 상세 조회 시, 상호명, 최소주문 금액, 전화번호, 배달팁, 메뉴명, 메뉴 설명, 메뉴 가격 조회")
     void whenFindShop_thenReturnDetailInfo() {
 


### PR DESCRIPTION
## 🔎 작업 내용

- 필요 없는 옵션 그룹, 옵션 레포지토리 삭제
- QueryDSL 설정
- 매장 조회 페이징 구현
- 매장 조회 정렬 구현
    - 최신 등록 순 정렬(id순)
    - 최소 주문 금액 낮은 순 정렬
    - 배달팁 낮은 순 정렬
## 🔧 앞으로의 과제

- 지역 테이블 생성
- 가까운 거리순 정렬 구현

## ✅ 해결 이슈

- resolved #10 
