### PR TITLE
옵션그룹과 옵션의 생명주기 분리 작업

### DIFF
--- a/src/main/java/com/oheat/food/controller/MenuController.java
+++ b/src/main/java/com/oheat/food/controller/MenuController.java
@@ -3,6 +3,8 @@ package com.oheat.food.controller;
 import com.oheat.food.dto.MenuFindByShopIdResponse;
 import com.oheat.food.dto.MenuSaveRequest;
 import com.oheat.food.dto.MenuUpdateRequest;
+import com.oheat.food.dto.OptionGroupSaveRequest;
+import com.oheat.food.dto.OptionGroupUpdateRequest;
 import com.oheat.food.dto.OptionSaveRequest;
 import com.oheat.food.dto.OptionUpdateRequest;
 import com.oheat.food.service.MenuService;
@@ -26,6 +28,7 @@ public class MenuController {
 
     private final MenuService menuService;
 
+    // Menu CRUD
     @PostMapping
     public ResponseEntity<?> registerMenu(@RequestBody MenuSaveRequest saveRequest) {
         menuService.registerMenu(saveRequest);
@@ -51,6 +54,27 @@ public class MenuController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    // OptionGroup CRUD
+    @PostMapping("/options/groups")
+    public ResponseEntity<?> registerOptionGroup(@RequestBody OptionGroupSaveRequest saveRequest) {
+        menuService.registerOptionGroup(saveRequest);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PutMapping("/options/groups")
+    public ResponseEntity<?> updateOptionGroup(
+        @RequestBody OptionGroupUpdateRequest updateRequest) {
+        menuService.updateOptionGroup(updateRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/options/groups/{id}")
+    public ResponseEntity<?> deleteOptionGroup(@PathVariable(name = "id") Long optionGroupId) {
+        menuService.deleteOptionGroup(optionGroupId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    // Option CRUD
     @PostMapping("/options")
     public ResponseEntity<?> registerOption(@RequestBody OptionSaveRequest saveRequest) {
         menuService.registerOption(saveRequest);

--- a/src/main/java/com/oheat/food/controller/MenuController.java
+++ b/src/main/java/com/oheat/food/controller/MenuController.java
@@ -3,6 +3,8 @@ package com.oheat.food.controller;
 import com.oheat.food.dto.MenuFindByShopIdResponse;
 import com.oheat.food.dto.MenuSaveRequest;
 import com.oheat.food.dto.MenuUpdateRequest;
+import com.oheat.food.dto.OptionSaveRequest;
+import com.oheat.food.dto.OptionUpdateRequest;
 import com.oheat.food.service.MenuService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +48,24 @@ public class MenuController {
     @DeleteMapping("{id}")
     public ResponseEntity<?> deleteMenu(@PathVariable(name = "id") Long menuId) {
         menuService.deleteById(menuId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/options")
+    public ResponseEntity<?> registerOption(@RequestBody OptionSaveRequest saveRequest) {
+        menuService.registerOption(saveRequest);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PutMapping("/options")
+    public ResponseEntity<?> updateOption(@RequestBody OptionUpdateRequest updateRequest) {
+        menuService.updateOption(updateRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/options/{id}")
+    public ResponseEntity<?> deleteOption(@PathVariable(name = "id") Long optionId) {
+        menuService.deleteOption(optionId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/oheat/food/dto/MenuSaveRequest.java
+++ b/src/main/java/com/oheat/food/dto/MenuSaveRequest.java
@@ -2,7 +2,6 @@ package com.oheat.food.dto;
 
 import com.oheat.food.entity.MenuJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,19 +14,12 @@ public class MenuSaveRequest {
     private final String name;
     private final int price;
     private final Long shopId;
-    private final List<OptionGroupSaveRequest> optionGroups;
 
     public MenuJpaEntity toEntity(ShopJpaEntity shop) {
-        MenuJpaEntity menu = MenuJpaEntity.builder()
+        return MenuJpaEntity.builder()
             .name(this.name)
             .price(this.price)
             .shop(shop)
             .build();
-
-        optionGroups.forEach(optionGroupSaveRequest -> {
-            menu.addOptionGroup(optionGroupSaveRequest.toEntity(menu));
-        });
-
-        return menu;
     }
 }

--- a/src/main/java/com/oheat/food/dto/MenuUpdateRequest.java
+++ b/src/main/java/com/oheat/food/dto/MenuUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.oheat.food.dto;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -14,5 +13,4 @@ public class MenuUpdateRequest {
     private final String name;
     private final int price;
     private final Long shopId;
-    private final List<OptionGroupUpdateRequest> optionGroups;
 }

--- a/src/main/java/com/oheat/food/dto/OptionGroupSaveRequest.java
+++ b/src/main/java/com/oheat/food/dto/OptionGroupSaveRequest.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OptionGroupSaveRequest {
 
+    private final Long menuId;
     private final String name;
     private final boolean required;
     private final int maxNumOfSelect;

--- a/src/main/java/com/oheat/food/dto/OptionGroupSaveRequest.java
+++ b/src/main/java/com/oheat/food/dto/OptionGroupSaveRequest.java
@@ -2,7 +2,6 @@ package com.oheat.food.dto;
 
 import com.oheat.food.entity.MenuJpaEntity;
 import com.oheat.food.entity.OptionGroupJpaEntity;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,20 +14,13 @@ public class OptionGroupSaveRequest {
     private final String name;
     private final boolean required;
     private final int maxNumOfSelect;
-    private final List<OptionSaveRequest> options;
 
     public OptionGroupJpaEntity toEntity(MenuJpaEntity menu) {
-        OptionGroupJpaEntity optionGroup = OptionGroupJpaEntity.builder()
+        return OptionGroupJpaEntity.builder()
             .name(this.name)
             .required(this.required)
             .maxNumOfSelect(this.maxNumOfSelect)
             .menu(menu)
             .build();
-
-        options.forEach(optionSaveRequest -> {
-            optionGroup.addOption(optionSaveRequest.toEntity(optionGroup));
-        });
-
-        return optionGroup;
     }
 }

--- a/src/main/java/com/oheat/food/dto/OptionGroupUpdateRequest.java
+++ b/src/main/java/com/oheat/food/dto/OptionGroupUpdateRequest.java
@@ -2,7 +2,6 @@ package com.oheat.food.dto;
 
 import com.oheat.food.entity.MenuJpaEntity;
 import com.oheat.food.entity.OptionGroupJpaEntity;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -15,20 +14,13 @@ public class OptionGroupUpdateRequest {
     private final String name;
     private final boolean required;
     private final int maxNumOfSelect;
-    private final List<OptionUpdateRequest> options;
 
     public OptionGroupJpaEntity toEntity(MenuJpaEntity menu) {
-        OptionGroupJpaEntity optionGroup = OptionGroupJpaEntity.builder()
+        return OptionGroupJpaEntity.builder()
             .name(this.name)
             .required(this.required)
             .maxNumOfSelect(this.maxNumOfSelect)
             .menu(menu)
             .build();
-
-        options.forEach(optionSaveRequest -> {
-            optionGroup.addOption(optionSaveRequest.toEntity(optionGroup));
-        });
-
-        return optionGroup;
     }
 }

--- a/src/main/java/com/oheat/food/dto/OptionGroupUpdateRequest.java
+++ b/src/main/java/com/oheat/food/dto/OptionGroupUpdateRequest.java
@@ -1,7 +1,5 @@
 package com.oheat.food.dto;
 
-import com.oheat.food.entity.MenuJpaEntity;
-import com.oheat.food.entity.OptionGroupJpaEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,16 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OptionGroupUpdateRequest {
 
+    private final Long optionGroupId;
     private final String name;
     private final boolean required;
     private final int maxNumOfSelect;
-
-    public OptionGroupJpaEntity toEntity(MenuJpaEntity menu) {
-        return OptionGroupJpaEntity.builder()
-            .name(this.name)
-            .required(this.required)
-            .maxNumOfSelect(this.maxNumOfSelect)
-            .menu(menu)
-            .build();
-    }
 }

--- a/src/main/java/com/oheat/food/dto/OptionSaveRequest.java
+++ b/src/main/java/com/oheat/food/dto/OptionSaveRequest.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OptionSaveRequest {
 
+    private final Long optionGroupId;
     private final String name;
     private final int price;
 

--- a/src/main/java/com/oheat/food/dto/OptionUpdateRequest.java
+++ b/src/main/java/com/oheat/food/dto/OptionUpdateRequest.java
@@ -1,7 +1,5 @@
 package com.oheat.food.dto;
 
-import com.oheat.food.entity.OptionGroupJpaEntity;
-import com.oheat.food.entity.OptionJpaEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,14 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OptionUpdateRequest {
 
+    private final Long optionId;
     private final String name;
     private final int price;
-
-    public OptionJpaEntity toEntity(OptionGroupJpaEntity optionGroup) {
-        return OptionJpaEntity.builder()
-            .name(this.name)
-            .price(this.price)
-            .optionGroup(optionGroup)
-            .build();
-    }
 }

--- a/src/main/java/com/oheat/food/entity/MenuJpaEntity.java
+++ b/src/main/java/com/oheat/food/entity/MenuJpaEntity.java
@@ -2,7 +2,6 @@ package com.oheat.food.entity;
 
 import com.oheat.common.BaseTimeEntity;
 import com.oheat.food.dto.MenuUpdateRequest;
-import com.oheat.food.exception.NoOptionException;
 import com.oheat.food.exception.NoOptionGroupException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -69,21 +68,9 @@ public class MenuJpaEntity extends BaseTimeEntity {
         if (isOptionGroupsEmpty()) {
             throw new NoOptionGroupException();
         }
-        if (isEmptyOptionGroupExists()) {
-            throw new NoOptionException();
-        }
     }
 
     public boolean isOptionGroupsEmpty() {
         return optionGroups.isEmpty();
-    }
-
-    public boolean isEmptyOptionGroupExists() {
-        for (OptionGroupJpaEntity optionGroup : optionGroups) {
-            if (optionGroup.isOptionsEmpty()) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/com/oheat/food/entity/MenuJpaEntity.java
+++ b/src/main/java/com/oheat/food/entity/MenuJpaEntity.java
@@ -2,7 +2,6 @@ package com.oheat.food.entity;
 
 import com.oheat.common.BaseTimeEntity;
 import com.oheat.food.dto.MenuUpdateRequest;
-import com.oheat.food.exception.NoOptionGroupException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -50,7 +49,7 @@ public class MenuJpaEntity extends BaseTimeEntity {
     @JoinColumn(name = "shop_id", nullable = false)
     private ShopJpaEntity shop;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "menu", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "menu", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<OptionGroupJpaEntity> optionGroups = new ArrayList<>();
 
     public void addOptionGroup(OptionGroupJpaEntity optionGroup) {
@@ -60,14 +59,6 @@ public class MenuJpaEntity extends BaseTimeEntity {
     public void updateMenu(MenuUpdateRequest updateRequest) {
         this.name = updateRequest.getName();
         this.price = updateRequest.getPrice();
-        this.optionGroups.clear();
-        updateRequest.getOptionGroups().forEach(optionGroupUpdateRequest -> {
-            this.optionGroups.add(optionGroupUpdateRequest.toEntity(this));
-        });
-
-        if (isOptionGroupsEmpty()) {
-            throw new NoOptionGroupException();
-        }
     }
 
     public boolean isOptionGroupsEmpty() {

--- a/src/main/java/com/oheat/food/entity/OptionGroupJpaEntity.java
+++ b/src/main/java/com/oheat/food/entity/OptionGroupJpaEntity.java
@@ -1,6 +1,8 @@
 package com.oheat.food.entity;
 
 import com.oheat.common.BaseTimeEntity;
+import com.oheat.food.dto.OptionGroupUpdateRequest;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -52,7 +54,7 @@ public class OptionGroupJpaEntity extends BaseTimeEntity {
     @JoinColumn(name = "menu_id", nullable = false)
     private MenuJpaEntity menu;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "optionGroup", orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "optionGroup", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private final List<OptionJpaEntity> options = new ArrayList<>();
 
     public void addOption(OptionJpaEntity option) {
@@ -61,5 +63,11 @@ public class OptionGroupJpaEntity extends BaseTimeEntity {
 
     public boolean isOptionsEmpty() {
         return options.isEmpty();
+    }
+
+    public void updateOptionGroupInfo(OptionGroupUpdateRequest updateRequest) {
+        this.name = updateRequest.getName();
+        this.required = updateRequest.isRequired();
+        this.maxNumOfSelect = updateRequest.getMaxNumOfSelect();
     }
 }

--- a/src/main/java/com/oheat/food/entity/OptionGroupJpaEntity.java
+++ b/src/main/java/com/oheat/food/entity/OptionGroupJpaEntity.java
@@ -1,7 +1,6 @@
 package com.oheat.food.entity;
 
 import com.oheat.common.BaseTimeEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -53,7 +52,7 @@ public class OptionGroupJpaEntity extends BaseTimeEntity {
     @JoinColumn(name = "menu_id", nullable = false)
     private MenuJpaEntity menu;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "optionGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "optionGroup", orphanRemoval = true)
     private final List<OptionJpaEntity> options = new ArrayList<>();
 
     public void addOption(OptionJpaEntity option) {

--- a/src/main/java/com/oheat/food/entity/OptionJpaEntity.java
+++ b/src/main/java/com/oheat/food/entity/OptionJpaEntity.java
@@ -1,6 +1,7 @@
 package com.oheat.food.entity;
 
 import com.oheat.common.BaseTimeEntity;
+import com.oheat.food.dto.OptionUpdateRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -43,4 +44,9 @@ public class OptionJpaEntity extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "option_group_id", nullable = false)
     private OptionGroupJpaEntity optionGroup;
+
+    public void updateOptionInfo(OptionUpdateRequest updateRequest) {
+        this.name = updateRequest.getName();
+        this.price = updateRequest.getPrice();
+    }
 }

--- a/src/main/java/com/oheat/food/exception/OptionGroupNotExistsException.java
+++ b/src/main/java/com/oheat/food/exception/OptionGroupNotExistsException.java
@@ -1,0 +1,5 @@
+package com.oheat.food.exception;
+
+public class OptionGroupNotExistsException extends RuntimeException {
+
+}

--- a/src/main/java/com/oheat/food/exception/OptionNotExistsException.java
+++ b/src/main/java/com/oheat/food/exception/OptionNotExistsException.java
@@ -1,0 +1,5 @@
+package com.oheat.food.exception;
+
+public class OptionNotExistsException extends RuntimeException {
+
+}

--- a/src/main/java/com/oheat/food/repository/OptionGroupJpaRepository.java
+++ b/src/main/java/com/oheat/food/repository/OptionGroupJpaRepository.java
@@ -1,4 +1,4 @@
-package com.oheat.food.jpaTest;
+package com.oheat.food.repository;
 
 import com.oheat.food.entity.OptionGroupJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/oheat/food/repository/OptionGroupRepository.java
+++ b/src/main/java/com/oheat/food/repository/OptionGroupRepository.java
@@ -5,5 +5,9 @@ import java.util.Optional;
 
 public interface OptionGroupRepository {
 
+    void save(OptionGroupJpaEntity optionGroup);
+
     Optional<OptionGroupJpaEntity> findById(Long optionGroupId);
+
+    void delete(OptionGroupJpaEntity optionGroup);
 }

--- a/src/main/java/com/oheat/food/repository/OptionGroupRepository.java
+++ b/src/main/java/com/oheat/food/repository/OptionGroupRepository.java
@@ -1,0 +1,9 @@
+package com.oheat.food.repository;
+
+import com.oheat.food.entity.OptionGroupJpaEntity;
+import java.util.Optional;
+
+public interface OptionGroupRepository {
+
+    Optional<OptionGroupJpaEntity> findById(Long optionGroupId);
+}

--- a/src/main/java/com/oheat/food/repository/OptionGroupRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/OptionGroupRepositoryImpl.java
@@ -12,7 +12,17 @@ public class OptionGroupRepositoryImpl implements OptionGroupRepository {
     private final OptionGroupJpaRepository optionGroupJpaRepository;
 
     @Override
+    public void save(OptionGroupJpaEntity optionGroup) {
+        optionGroupJpaRepository.save(optionGroup);
+    }
+
+    @Override
     public Optional<OptionGroupJpaEntity> findById(Long optionGroupId) {
         return optionGroupJpaRepository.findById(optionGroupId);
+    }
+
+    @Override
+    public void delete(OptionGroupJpaEntity optionGroup) {
+        optionGroupJpaRepository.delete(optionGroup);
     }
 }

--- a/src/main/java/com/oheat/food/repository/OptionGroupRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/OptionGroupRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.oheat.food.repository;
+
+import com.oheat.food.entity.OptionGroupJpaEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class OptionGroupRepositoryImpl implements OptionGroupRepository {
+
+    private final OptionGroupJpaRepository optionGroupJpaRepository;
+
+    @Override
+    public Optional<OptionGroupJpaEntity> findById(Long optionGroupId) {
+        return optionGroupJpaRepository.findById(optionGroupId);
+    }
+}

--- a/src/main/java/com/oheat/food/repository/OptionJpaRepository.java
+++ b/src/main/java/com/oheat/food/repository/OptionJpaRepository.java
@@ -1,4 +1,4 @@
-package com.oheat.food.jpaTest;
+package com.oheat.food.repository;
 
 import com.oheat.food.entity.OptionJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/oheat/food/repository/OptionRepository.java
+++ b/src/main/java/com/oheat/food/repository/OptionRepository.java
@@ -1,0 +1,13 @@
+package com.oheat.food.repository;
+
+import com.oheat.food.entity.OptionJpaEntity;
+import java.util.Optional;
+
+public interface OptionRepository {
+
+    void save(OptionJpaEntity option);
+
+    Optional<OptionJpaEntity> findById(Long optionId);
+
+    void delete(OptionJpaEntity option);
+}

--- a/src/main/java/com/oheat/food/repository/OptionRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/OptionRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.oheat.food.repository;
+
+import com.oheat.food.entity.OptionJpaEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class OptionRepositoryImpl implements OptionRepository {
+
+    private final OptionJpaRepository optionJpaRepository;
+
+    @Override
+    public void save(OptionJpaEntity option) {
+        optionJpaRepository.save(option);
+    }
+
+    @Override
+    public Optional<OptionJpaEntity> findById(Long optionId) {
+        return optionJpaRepository.findById(optionId);
+    }
+
+    @Override
+    public void delete(OptionJpaEntity option) {
+        optionJpaRepository.delete(option);
+    }
+}

--- a/src/main/java/com/oheat/food/service/MenuService.java
+++ b/src/main/java/com/oheat/food/service/MenuService.java
@@ -2,6 +2,8 @@ package com.oheat.food.service;
 
 import com.oheat.food.dto.MenuSaveRequest;
 import com.oheat.food.dto.MenuUpdateRequest;
+import com.oheat.food.dto.OptionGroupSaveRequest;
+import com.oheat.food.dto.OptionGroupUpdateRequest;
 import com.oheat.food.dto.OptionSaveRequest;
 import com.oheat.food.dto.OptionUpdateRequest;
 import com.oheat.food.entity.MenuJpaEntity;
@@ -9,7 +11,6 @@ import com.oheat.food.entity.OptionGroupJpaEntity;
 import com.oheat.food.entity.OptionJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.exception.MenuNotExistsException;
-import com.oheat.food.exception.NoOptionGroupException;
 import com.oheat.food.exception.OptionGroupNotExistsException;
 import com.oheat.food.exception.OptionNotExistsException;
 import com.oheat.food.exception.ShopNotExistsException;
@@ -38,9 +39,6 @@ public class MenuService {
 
         MenuJpaEntity menu = saveRequest.toEntity(shop);
         shop.addMenu(menu);
-        if (menu.isOptionGroupsEmpty()) {
-            throw new NoOptionGroupException();
-        }
         menuRepository.save(menu);
     }
 
@@ -65,6 +63,30 @@ public class MenuService {
         menuRepository.findById(menuId)
             .orElseThrow(MenuNotExistsException::new);
         menuRepository.deleteById(menuId);
+    }
+
+    // option group CRUD
+    public void registerOptionGroup(OptionGroupSaveRequest saveRequest) {
+        MenuJpaEntity menu = menuRepository.findById(saveRequest.getMenuId())
+            .orElseThrow(MenuNotExistsException::new);
+
+        optionGroupRepository.save(saveRequest.toEntity(menu));
+    }
+
+    @Transactional
+    public void updateOptionGroup(OptionGroupUpdateRequest updateRequest) {
+        OptionGroupJpaEntity optionGroup = optionGroupRepository.findById(
+                updateRequest.getOptionGroupId())
+            .orElseThrow(OptionGroupNotExistsException::new);
+
+        optionGroup.updateOptionGroupInfo(updateRequest);
+    }
+
+    public void deleteOptionGroup(Long optionGroupId) {
+        OptionGroupJpaEntity optionGroup = optionGroupRepository.findById(optionGroupId)
+            .orElseThrow(OptionGroupNotExistsException::new);
+
+        optionGroupRepository.delete(optionGroup);
     }
 
     // option CRUD

--- a/src/main/java/com/oheat/food/service/MenuService.java
+++ b/src/main/java/com/oheat/food/service/MenuService.java
@@ -2,13 +2,20 @@ package com.oheat.food.service;
 
 import com.oheat.food.dto.MenuSaveRequest;
 import com.oheat.food.dto.MenuUpdateRequest;
+import com.oheat.food.dto.OptionSaveRequest;
+import com.oheat.food.dto.OptionUpdateRequest;
 import com.oheat.food.entity.MenuJpaEntity;
+import com.oheat.food.entity.OptionGroupJpaEntity;
+import com.oheat.food.entity.OptionJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.exception.MenuNotExistsException;
-import com.oheat.food.exception.NoOptionException;
 import com.oheat.food.exception.NoOptionGroupException;
+import com.oheat.food.exception.OptionGroupNotExistsException;
+import com.oheat.food.exception.OptionNotExistsException;
 import com.oheat.food.exception.ShopNotExistsException;
 import com.oheat.food.repository.MenuRepository;
+import com.oheat.food.repository.OptionGroupRepository;
+import com.oheat.food.repository.OptionRepository;
 import com.oheat.food.repository.ShopRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +26,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class MenuService {
 
-    private final MenuRepository menuRepository;
     private final ShopRepository shopRepository;
+    private final MenuRepository menuRepository;
+    private final OptionGroupRepository optionGroupRepository;
+    private final OptionRepository optionRepository;
 
+    // Menu CRUD
     public void registerMenu(MenuSaveRequest saveRequest) {
         ShopJpaEntity shop = shopRepository.findById(saveRequest.getShopId())
             .orElseThrow(ShopNotExistsException::new);
@@ -30,9 +40,6 @@ public class MenuService {
         shop.addMenu(menu);
         if (menu.isOptionGroupsEmpty()) {
             throw new NoOptionGroupException();
-        }
-        if (menu.isEmptyOptionGroupExists()) {
-            throw new NoOptionException();
         }
         menuRepository.save(menu);
     }
@@ -58,5 +65,28 @@ public class MenuService {
         menuRepository.findById(menuId)
             .orElseThrow(MenuNotExistsException::new);
         menuRepository.deleteById(menuId);
+    }
+
+    // option CRUD
+    public void registerOption(OptionSaveRequest optionSaveRequest) {
+        OptionGroupJpaEntity optionGroup = optionGroupRepository.findById(
+                optionSaveRequest.getOptionGroupId())
+            .orElseThrow(OptionGroupNotExistsException::new);
+
+        optionRepository.save(optionSaveRequest.toEntity(optionGroup));
+    }
+
+    @Transactional
+    public void updateOption(OptionUpdateRequest updateRequest) {
+        OptionJpaEntity option = optionRepository.findById(updateRequest.getOptionId())
+            .orElseThrow(OptionNotExistsException::new);
+
+        option.updateOptionInfo(updateRequest);
+    }
+
+    public void deleteOption(Long optionId) {
+        OptionJpaEntity option = optionRepository.findById(optionId)
+            .orElseThrow(OptionNotExistsException::new);
+        optionRepository.delete(option);
     }
 }

--- a/src/test/java/com/oheat/food/fake/MemoryOptionGroupRepository.java
+++ b/src/test/java/com/oheat/food/fake/MemoryOptionGroupRepository.java
@@ -1,0 +1,18 @@
+package com.oheat.food.fake;
+
+import com.oheat.food.entity.OptionGroupJpaEntity;
+import com.oheat.food.repository.OptionGroupRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class MemoryOptionGroupRepository implements OptionGroupRepository {
+
+    private final Map<Long, OptionGroupJpaEntity> options = new HashMap<>();
+    private Long autoId = 1L;
+
+    @Override
+    public Optional<OptionGroupJpaEntity> findById(Long optionGroupId) {
+        return Optional.ofNullable(options.get(optionGroupId));
+    }
+}

--- a/src/test/java/com/oheat/food/fake/MemoryOptionGroupRepository.java
+++ b/src/test/java/com/oheat/food/fake/MemoryOptionGroupRepository.java
@@ -8,11 +8,26 @@ import java.util.Optional;
 
 public class MemoryOptionGroupRepository implements OptionGroupRepository {
 
-    private final Map<Long, OptionGroupJpaEntity> options = new HashMap<>();
+    private final Map<Long, OptionGroupJpaEntity> groups = new HashMap<>();
     private Long autoId = 1L;
 
     @Override
+    public void save(OptionGroupJpaEntity optionGroup) {
+        groups.put(autoId++, optionGroup);
+    }
+
+    @Override
     public Optional<OptionGroupJpaEntity> findById(Long optionGroupId) {
-        return Optional.ofNullable(options.get(optionGroupId));
+        return Optional.ofNullable(groups.get(optionGroupId));
+    }
+
+    @Override
+    public void delete(OptionGroupJpaEntity optionGroup) {
+        Long target = groups.entrySet().stream()
+            .filter(entry -> entry.getValue().equals(optionGroup))
+            .findFirst()
+            .get().getKey();
+
+        groups.remove(target);
     }
 }

--- a/src/test/java/com/oheat/food/fake/MemoryOptionRepository.java
+++ b/src/test/java/com/oheat/food/fake/MemoryOptionRepository.java
@@ -1,0 +1,32 @@
+package com.oheat.food.fake;
+
+import com.oheat.food.entity.OptionJpaEntity;
+import com.oheat.food.repository.OptionRepository;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class MemoryOptionRepository implements OptionRepository {
+
+    private final Map<Long, OptionJpaEntity> options = new HashMap<>();
+    private Long autoId = 1L;
+
+    @Override
+    public void save(OptionJpaEntity option) {
+        options.put(autoId++, option);
+    }
+
+    @Override
+    public Optional<OptionJpaEntity> findById(Long optionId) {
+        return Optional.ofNullable(options.get(optionId));
+    }
+
+    @Override
+    public void delete(OptionJpaEntity option) {
+        Long target = options.entrySet().stream()
+            .filter(entry -> entry.getValue().equals(option))
+            .findFirst()
+            .get().getKey();
+        options.remove(target);
+    }
+}

--- a/src/test/java/com/oheat/food/jpaTest/MenuRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/MenuRepositoryTest.java
@@ -113,8 +113,8 @@ public class MenuRepositoryTest {
 
         // 저장 과정에서 예외 발생 X
         Assertions.assertDoesNotThrow(() -> {
-            menu.addOptionGroup(optionGroup);
             menuJpaRepository.save(menu);
+            optionGroupJpaRepository.save(optionGroup);
             optionJpaRepository.save(option);
         });
         entityManager.clear();
@@ -150,13 +150,11 @@ public class MenuRepositoryTest {
         categoryJpaRepository.save(category);
         shopJpaRepository.save(shop);
 
-        // 옵션 그룹 2개
-        menu.addOptionGroup(optionGroup1);
-        menu.addOptionGroup(optionGroup2);
-
         // 메뉴 저장
         menuJpaRepository.save(menu);
-
+        // 옵션 그룹 2개
+        optionGroupJpaRepository.save(optionGroup1);
+        optionGroupJpaRepository.save(optionGroup2);
         // 각 옵션 그룹마다 옵션 2개씩
         optionJpaRepository.save(option1);
         optionJpaRepository.save(option2);
@@ -185,13 +183,12 @@ public class MenuRepositoryTest {
 
         categoryJpaRepository.save(category);
         shopJpaRepository.save(shop);
-
-        optionGroup.addOption(option);
-        menu.addOptionGroup(optionGroup);
         menuJpaRepository.save(menu);
+        optionGroupJpaRepository.save(optionGroup);
         optionJpaRepository.save(option);
 
-        menuJpaRepository.delete(menu);
+        entityManager.clear();
+        menuJpaRepository.deleteById(1L);
 
         List<MenuJpaEntity> menuResult = menuJpaRepository.findAll();
         List<OptionGroupJpaEntity> optionGroupResult = optionGroupJpaRepository.findAll();

--- a/src/test/java/com/oheat/food/serviceTest/MenuCRUDTest.java
+++ b/src/test/java/com/oheat/food/serviceTest/MenuCRUDTest.java
@@ -10,7 +10,6 @@ import com.oheat.food.entity.MenuJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.exception.DuplicateMenuException;
 import com.oheat.food.exception.MenuNotExistsException;
-import com.oheat.food.exception.NoOptionGroupException;
 import com.oheat.food.exception.ShopNotExistsException;
 import com.oheat.food.fake.MemoryMenuRepository;
 import com.oheat.food.fake.MemoryOptionGroupRepository;
@@ -53,20 +52,6 @@ public class MenuCRUDTest {
     }
 
     @Test
-    @DisplayName("메뉴 등록 시, 옵션 그룹 정보가 없다면 메뉴 등록 실패")
-    void givenMenuWithoutOptionGroup_whenAddNewMenu_thenFail() {
-        memoryShopRepository.save(ShopJpaEntity.builder().name("bbq").build());
-
-        Assertions.assertThrows(NoOptionGroupException.class, () -> {
-            menuService.registerMenu(MenuSaveRequest.builder()
-                .name("황올")
-                .shopId(1L)
-                .optionGroups(List.of())
-                .build());
-        });
-    }
-
-    @Test
     @DisplayName("메뉴 등록 시, 1개 이상의 옵션 그룹이 존재하고 각 옵션 그룹에 옵션이 1개 이상이라면 메뉴 등록 성공")
     void givenMenuWithNotEmptyOptionGroup_whenAddNewMenu_thenSuccess() {
         memoryShopRepository.save(ShopJpaEntity.builder().name("bbq").build());
@@ -81,7 +66,6 @@ public class MenuCRUDTest {
             menuService.registerMenu(MenuSaveRequest.builder()
                 .name("황금올리브")
                 .shopId(1L)
-                .optionGroups(List.of(optionGroup))
                 .build());
         });
     }
@@ -97,11 +81,11 @@ public class MenuCRUDTest {
             .maxNumOfSelect(1)
             .build();
         menuService.registerMenu(MenuSaveRequest.builder()
-            .name("황금올리브").shopId(1L).optionGroups(List.of(optionGroup)).build());
+            .name("황금올리브").shopId(1L).build());
 
         Assertions.assertThrows(DuplicateMenuException.class, () -> {
             menuService.registerMenu(MenuSaveRequest.builder()
-                .name("황금올리브").shopId(1L).optionGroups(List.of(optionGroup)).build());
+                .name("황금올리브").shopId(1L).build());
         });
     }
 
@@ -120,7 +104,6 @@ public class MenuCRUDTest {
             menuService.registerMenu(MenuSaveRequest.builder()
                 .name("황올 세트 " + i + "번")
                 .shopId(1L)
-                .optionGroups(List.of(optionGroup))
                 .build());
         }
 
@@ -178,7 +161,6 @@ public class MenuCRUDTest {
                 .menuId(1L)
                 .shopId(1L)
                 .name("양념치킨")
-                .optionGroups(List.of(optionGroupUpdateRequest))
                 .build());
         });
         assertThat(memoryMenuRepository.findById(1L).get().getName())

--- a/src/test/java/com/oheat/food/serviceTest/MenuCRUDTest.java
+++ b/src/test/java/com/oheat/food/serviceTest/MenuCRUDTest.java
@@ -6,18 +6,19 @@ import com.oheat.food.dto.MenuSaveRequest;
 import com.oheat.food.dto.MenuUpdateRequest;
 import com.oheat.food.dto.OptionGroupSaveRequest;
 import com.oheat.food.dto.OptionGroupUpdateRequest;
-import com.oheat.food.dto.OptionSaveRequest;
-import com.oheat.food.dto.OptionUpdateRequest;
 import com.oheat.food.entity.MenuJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.exception.DuplicateMenuException;
 import com.oheat.food.exception.MenuNotExistsException;
-import com.oheat.food.exception.NoOptionException;
 import com.oheat.food.exception.NoOptionGroupException;
 import com.oheat.food.exception.ShopNotExistsException;
 import com.oheat.food.fake.MemoryMenuRepository;
+import com.oheat.food.fake.MemoryOptionGroupRepository;
+import com.oheat.food.fake.MemoryOptionRepository;
 import com.oheat.food.fake.MemoryShopRepository;
 import com.oheat.food.repository.MenuRepository;
+import com.oheat.food.repository.OptionGroupRepository;
+import com.oheat.food.repository.OptionRepository;
 import com.oheat.food.repository.ShopRepository;
 import com.oheat.food.service.MenuService;
 import java.util.List;
@@ -29,12 +30,15 @@ import org.junit.jupiter.api.Test;
 public class MenuCRUDTest {
 
     private MenuService menuService;
-    private final MenuRepository memoryMenuRepository = new MemoryMenuRepository();
     private final ShopRepository memoryShopRepository = new MemoryShopRepository();
+    private final MenuRepository memoryMenuRepository = new MemoryMenuRepository();
+    private final OptionGroupRepository memoryOptionGroupRepository = new MemoryOptionGroupRepository();
+    private final OptionRepository memoryOptionRepository = new MemoryOptionRepository();
 
     @BeforeEach
     void setUp() {
-        menuService = new MenuService(memoryMenuRepository, memoryShopRepository);
+        menuService = new MenuService(memoryShopRepository, memoryMenuRepository,
+            memoryOptionGroupRepository, memoryOptionRepository);
     }
 
     @Test
@@ -63,26 +67,6 @@ public class MenuCRUDTest {
     }
 
     @Test
-    @DisplayName("메뉴 등록 시, 옵션이 존재하지 않는 옵션 그룹이 있다면 메뉴 등록 실패")
-    void givenMenuWithEmptyOptionGroup_whenAddNewMenu_thenFail() {
-        memoryShopRepository.save(ShopJpaEntity.builder().name("bbq").build());
-        OptionGroupSaveRequest optionGroup = OptionGroupSaveRequest.builder()
-            .name("부분육 선택")
-            .required(true)
-            .maxNumOfSelect(1)
-            .options(List.of())
-            .build();
-
-        Assertions.assertThrows(NoOptionException.class, () -> {
-            menuService.registerMenu(MenuSaveRequest.builder()
-                .name("황올")
-                .shopId(1L)
-                .optionGroups(List.of(optionGroup))
-                .build());
-        });
-    }
-
-    @Test
     @DisplayName("메뉴 등록 시, 1개 이상의 옵션 그룹이 존재하고 각 옵션 그룹에 옵션이 1개 이상이라면 메뉴 등록 성공")
     void givenMenuWithNotEmptyOptionGroup_whenAddNewMenu_thenSuccess() {
         memoryShopRepository.save(ShopJpaEntity.builder().name("bbq").build());
@@ -91,10 +75,6 @@ public class MenuCRUDTest {
             .name("부분육 선택")
             .required(true)
             .maxNumOfSelect(1)
-            .options(List.of(OptionSaveRequest.builder()
-                .name("순살")
-                .price(2_000)
-                .build()))
             .build();
 
         Assertions.assertDoesNotThrow(() -> {
@@ -115,10 +95,6 @@ public class MenuCRUDTest {
             .name("부분육 선택")
             .required(true)
             .maxNumOfSelect(1)
-            .options(List.of(OptionSaveRequest.builder()
-                .name("순살")
-                .price(2_000)
-                .build()))
             .build();
         menuService.registerMenu(MenuSaveRequest.builder()
             .name("황금올리브").shopId(1L).optionGroups(List.of(optionGroup)).build());
@@ -138,10 +114,6 @@ public class MenuCRUDTest {
             .name("부분육 선택")
             .required(true)
             .maxNumOfSelect(1)
-            .options(List.of(OptionSaveRequest.builder()
-                .name("순살")
-                .price(2_000)
-                .build()))
             .build();
 
         for (int i = 0; i < 3; i++) {
@@ -199,10 +171,6 @@ public class MenuCRUDTest {
             .name("부분육 선택")
             .required(true)
             .maxNumOfSelect(3)
-            .options(List.of(OptionUpdateRequest.builder()
-                .name("닭다리")
-                .price(99_000)
-                .build()))
             .build();
 
         Assertions.assertDoesNotThrow(() -> {


### PR DESCRIPTION
## 🔎 작업 내용

- 옵션의 생명주기를 옵션 그룹으로부터 분리함
- 옵션그룹의 생명주기를 메뉴로부터 분리함
- 단, Casecade.REMOVE, orphanRemoval은 적용하였음
- 옵션그룹의 옵션의 API 추가로 구현

## 🔧 앞으로의 과제

- 장바구니 기능 구현

## ✅ 해결 이슈

- resolved #15 
