### PR TITLE
Address 엔티티 및 가까운 거리순 매장 조회 기능

### DIFF
--- a/src/main/java/com/oheat/common/config/WebConfig.java
+++ b/src/main/java/com/oheat/common/config/WebConfig.java
@@ -16,6 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
             .addPathPatterns("/api/v1/users/carts")
+            .addPathPatterns("/api/v1/users/address")
             .addPathPatterns("/api/v1/orders/**");
     }
 }

--- a/src/main/java/com/oheat/common/config/WebConfig.java
+++ b/src/main/java/com/oheat/common/config/WebConfig.java
@@ -16,7 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
             .addPathPatterns("/api/v1/users/carts")
-            .addPathPatterns("/api/v1/users/address")
+            .addPathPatterns("/api/v1/users/addresses/**")
             .addPathPatterns("/api/v1/orders/**");
     }
 }

--- a/src/main/java/com/oheat/food/controller/ShopController.java
+++ b/src/main/java/com/oheat/food/controller/ShopController.java
@@ -1,6 +1,6 @@
 package com.oheat.food.controller;
 
-import com.oheat.food.dto.ShopFindByCategoryResponse;
+import com.oheat.food.dto.ShopFindResponse;
 import com.oheat.food.dto.ShopSaveRequest;
 import com.oheat.food.dto.ShopUpdateRequest;
 import com.oheat.food.service.ShopService;
@@ -33,10 +33,9 @@ public class ShopController {
     }
 
     @GetMapping
-    public Page<ShopFindByCategoryResponse> findShopByCategory(
+    public Page<ShopFindResponse> findShopByCategory(
         @RequestParam String category, Pageable pageable) {
-        return shopService.findShopByCategory(category, pageable)
-            .map(ShopFindByCategoryResponse::from);
+        return shopService.findShopByCategory(category, pageable);
     }
 
     @PutMapping

--- a/src/main/java/com/oheat/food/controller/ShopController.java
+++ b/src/main/java/com/oheat/food/controller/ShopController.java
@@ -1,5 +1,6 @@
 package com.oheat.food.controller;
 
+import com.oheat.food.dto.ShopFindRequest;
 import com.oheat.food.dto.ShopFindResponse;
 import com.oheat.food.dto.ShopSaveRequest;
 import com.oheat.food.dto.ShopUpdateRequest;
@@ -34,8 +35,18 @@ public class ShopController {
 
     @GetMapping
     public Page<ShopFindResponse> findShopByCategory(
-        @RequestParam String category, Pageable pageable) {
-        return shopService.findShopByCategory(category, pageable);
+        @RequestParam String category,
+        @RequestParam(required = false) Double latitude,
+        @RequestParam(required = false) Double longitude,
+        Pageable pageable) {
+
+        ShopFindRequest findReq = ShopFindRequest.builder()
+            .categoryName(category)
+            .latitude(latitude)
+            .longitude(longitude)
+            .build();
+
+        return shopService.findShopByCategory(findReq, pageable);
     }
 
     @PutMapping

--- a/src/main/java/com/oheat/food/dto/Coordinates.java
+++ b/src/main/java/com/oheat/food/dto/Coordinates.java
@@ -1,0 +1,21 @@
+package com.oheat.food.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class Coordinates {
+
+    private final Double latitude;
+    private final Double longitude;
+
+    public static Coordinates from(ShopFindRequest findRequest) {
+        return Coordinates.builder()
+            .latitude(findRequest.getLatitude())
+            .longitude(findRequest.getLongitude())
+            .build();
+    }
+}

--- a/src/main/java/com/oheat/food/dto/ShopFindRequest.java
+++ b/src/main/java/com/oheat/food/dto/ShopFindRequest.java
@@ -1,0 +1,15 @@
+package com.oheat.food.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ShopFindRequest {
+
+    private final String categoryName;
+    private final Double latitude;
+    private final Double longitude;
+}

--- a/src/main/java/com/oheat/food/dto/ShopFindResponse.java
+++ b/src/main/java/com/oheat/food/dto/ShopFindResponse.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @Builder
 @RequiredArgsConstructor
-public class ShopFindByCategoryResponse {
+public class ShopFindResponse {
 
     private final Long id;
     private final String name;
@@ -16,15 +16,19 @@ public class ShopFindByCategoryResponse {
     private final String category;
     private final int minimumOrderAmount;
     private final int deliveryFee;
+    private final Double latitude;
+    private final Double longitude;
 
-    public static ShopFindByCategoryResponse from(ShopJpaEntity shopJpaEntity) {
-        return ShopFindByCategoryResponse.builder()
+    public static ShopFindResponse from(ShopJpaEntity shopJpaEntity) {
+        return ShopFindResponse.builder()
             .id(shopJpaEntity.getId())
             .name(shopJpaEntity.getName())
             .phone(shopJpaEntity.getPhone())
             .category(shopJpaEntity.getCategory().getName())
             .minimumOrderAmount(shopJpaEntity.getMinimumOrderAmount())
             .deliveryFee((shopJpaEntity.getDeliveryFee()))
+            .latitude(shopJpaEntity.getLatitude())
+            .longitude(shopJpaEntity.getLongitude())
             .build();
     }
 }

--- a/src/main/java/com/oheat/food/dto/ShopSaveRequest.java
+++ b/src/main/java/com/oheat/food/dto/ShopSaveRequest.java
@@ -16,6 +16,8 @@ public class ShopSaveRequest {
     private final String category;
     private final int minimumOrderAmount;
     private final int deliveryFee;
+    private final Double latitude;
+    private final Double longitude;
 
     public ShopJpaEntity toEntity(CategoryJpaEntity category) {
         return ShopJpaEntity.builder()
@@ -24,6 +26,8 @@ public class ShopSaveRequest {
             .category(category)
             .minimumOrderAmount(this.minimumOrderAmount)
             .deliveryFee(this.deliveryFee)
+            .latitude(this.latitude)
+            .longitude(this.longitude)
             .build();
     }
 }

--- a/src/main/java/com/oheat/food/dto/ShopUpdateRequest.java
+++ b/src/main/java/com/oheat/food/dto/ShopUpdateRequest.java
@@ -15,5 +15,6 @@ public class ShopUpdateRequest {
     private final String category;
     private final int minimumOrderAmount;
     private final int deliveryFee;
-
+    private final Double latitude;
+    private final Double longitude;
 }

--- a/src/main/java/com/oheat/food/entity/ShopJpaEntity.java
+++ b/src/main/java/com/oheat/food/entity/ShopJpaEntity.java
@@ -32,16 +32,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "shop")
 public class ShopJpaEntity extends BaseTimeEntity {
 
-    @Builder
-    public ShopJpaEntity(String name, String phone, CategoryJpaEntity category,
-        int minimumOrderAmount, int deliveryFee) {
-        this.name = name;
-        this.phone = phone;
-        this.category = category;
-        this.minimumOrderAmount = minimumOrderAmount;
-        this.deliveryFee = deliveryFee;
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -58,6 +48,12 @@ public class ShopJpaEntity extends BaseTimeEntity {
     @Column(name = "delivery_fee", nullable = false)
     private int deliveryFee;
 
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
     @ManyToOne
     @JoinColumn(name = "category", referencedColumnName = "name", nullable = false)
     private CategoryJpaEntity category;
@@ -68,12 +64,26 @@ public class ShopJpaEntity extends BaseTimeEntity {
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "shop")
     private final List<MenuGroupJpaEntity> menuGroups = new ArrayList<>();
 
+    @Builder
+    public ShopJpaEntity(String name, String phone, CategoryJpaEntity category,
+        int minimumOrderAmount, int deliveryFee, Double latitude, Double longitude) {
+        this.name = name;
+        this.phone = phone;
+        this.category = category;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.deliveryFee = deliveryFee;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
     public void updateShopInfo(ShopUpdateRequest updateRequest, CategoryJpaEntity category) {
         this.name = updateRequest.getName();
         this.phone = updateRequest.getPhone();
         this.category = category;
         this.minimumOrderAmount = updateRequest.getMinimumOrderAmount();
         this.deliveryFee = updateRequest.getDeliveryFee();
+        this.latitude = updateRequest.getLatitude();
+        this.longitude = updateRequest.getLongitude();
     }
 
     public void addMenu(MenuJpaEntity menu) {

--- a/src/main/java/com/oheat/food/repository/ShopCustomRepository.java
+++ b/src/main/java/com/oheat/food/repository/ShopCustomRepository.java
@@ -1,5 +1,6 @@
 package com.oheat.food.repository;
 
+import com.oheat.food.dto.Coordinates;
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import org.springframework.data.domain.Page;
@@ -7,5 +8,8 @@ import org.springframework.data.domain.Pageable;
 
 public interface ShopCustomRepository {
 
-    Page<ShopJpaEntity> findShopByCategory(CategoryJpaEntity category, Pageable pageable);
+    Page<ShopJpaEntity> findByCategory(CategoryJpaEntity category, Pageable pageable);
+
+    Page<ShopJpaEntity> findByCategoryOrderByDistance(CategoryJpaEntity category, Coordinates coordinates,
+        Pageable pageable);
 }

--- a/src/main/java/com/oheat/food/repository/ShopRepository.java
+++ b/src/main/java/com/oheat/food/repository/ShopRepository.java
@@ -1,5 +1,6 @@
 package com.oheat.food.repository;
 
+import com.oheat.food.dto.Coordinates;
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import java.util.Optional;
@@ -15,6 +16,9 @@ public interface ShopRepository {
     Optional<ShopJpaEntity> findByName(String name);
 
     Page<ShopJpaEntity> findByCategory(CategoryJpaEntity category, Pageable pageable);
+
+    Page<ShopJpaEntity> findByCategoryOrderByDistance(CategoryJpaEntity category, Coordinates coordinates,
+        Pageable pageable);
 
     void deleteById(Long shopId);
 }

--- a/src/main/java/com/oheat/food/repository/ShopRepositoryImpl.java
+++ b/src/main/java/com/oheat/food/repository/ShopRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.oheat.food.repository;
 
+import com.oheat.food.dto.Coordinates;
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import java.util.Optional;
@@ -31,7 +32,13 @@ public class ShopRepositoryImpl implements ShopRepository {
 
     @Override
     public Page<ShopJpaEntity> findByCategory(CategoryJpaEntity category, Pageable pageable) {
-        return shopJpaRepository.findShopByCategory(category, pageable);
+        return shopJpaRepository.findByCategory(category, pageable);
+    }
+
+    @Override
+    public Page<ShopJpaEntity> findByCategoryOrderByDistance(CategoryJpaEntity category, Coordinates coordinates,
+        Pageable pageable) {
+        return shopJpaRepository.findByCategoryOrderByDistance(category, coordinates, pageable);
     }
 
     @Override

--- a/src/main/java/com/oheat/food/service/ShopService.java
+++ b/src/main/java/com/oheat/food/service/ShopService.java
@@ -1,5 +1,6 @@
 package com.oheat.food.service;
 
+import com.oheat.food.dto.ShopFindResponse;
 import com.oheat.food.dto.ShopSaveRequest;
 import com.oheat.food.dto.ShopUpdateRequest;
 import com.oheat.food.entity.CategoryJpaEntity;
@@ -35,11 +36,12 @@ public class ShopService {
         shopRepository.save(saveRequest.toEntity(category));
     }
 
-    public Page<ShopJpaEntity> findShopByCategory(String categoryName, Pageable pageable) {
+    public Page<ShopFindResponse> findShopByCategory(String categoryName, Pageable pageable) {
         CategoryJpaEntity category = categoryRepository.findByName(categoryName)
             .orElseThrow(CategoryNotExistsException::new);
 
-        return shopRepository.findByCategory(category, pageable);
+        return shopRepository.findByCategory(category, pageable)
+            .map(ShopFindResponse::from);
     }
 
     @Transactional

--- a/src/main/java/com/oheat/order/dto/OrderSaveRequest.java
+++ b/src/main/java/com/oheat/order/dto/OrderSaveRequest.java
@@ -20,12 +20,15 @@ public class OrderSaveRequest {
     private final int deliveryFee;
     private final int discount;
     private final PayMethod payMethod;
+    private final String address;
+    private final String detailAddress;
 
     public Order toEntity(ShopJpaEntity shop, UserJpaEntity user, Payment payment) {
         return Order.builder()
             .id(payment.getOrderId())
             .orderState(OrderState.PENDING)
-            .address(user.getAddress())
+            .address(address)
+            .detailAddress(detailAddress)
             .phone(user.getPhone())
             .msgForShop(this.msgForShop)
             .deliveryFee(this.deliveryFee)

--- a/src/main/java/com/oheat/order/entity/Order.java
+++ b/src/main/java/com/oheat/order/entity/Order.java
@@ -43,6 +43,9 @@ public class Order extends BaseTimeEntity {
     @Column(name = "address", nullable = false)
     private String address;
 
+    @Column(name = "detail_address")
+    private String detailAddress;
+
     @Column(name = "phone", nullable = false)
     private String phone;
 
@@ -78,12 +81,13 @@ public class Order extends BaseTimeEntity {
     private Payment payment;
 
     @Builder
-    public Order(UUID id, OrderState orderState, String address, String phone, String msgForShop,
+    public Order(UUID id, OrderState orderState, String address, String detailAddress, String phone, String msgForShop,
         int deliveryFee, int discount, PayMethod payMethod, boolean reviewed, ShopJpaEntity shop,
         UserJpaEntity user, Payment payment) {
         this.id = id;
         this.orderState = orderState;
         this.address = address;
+        this.detailAddress = detailAddress;
         this.phone = phone;
         this.msgForShop = msgForShop;
         this.deliveryFee = deliveryFee;

--- a/src/main/java/com/oheat/user/controller/AddressController.java
+++ b/src/main/java/com/oheat/user/controller/AddressController.java
@@ -1,0 +1,45 @@
+package com.oheat.user.controller;
+
+import com.oheat.user.dto.AddressFindResponse;
+import com.oheat.user.dto.AddressSaveRequest;
+import com.oheat.user.service.AddressService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/users/addresses")
+public class AddressController {
+
+    private final AddressService addressService;
+
+    @PostMapping
+    public ResponseEntity<?> registerAddress(@RequestBody AddressSaveRequest saveRequest, HttpServletRequest http) {
+        String username = (String) http.getAttribute("username");
+        addressService.registerAddress(saveRequest, username);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public List<AddressFindResponse> findAllAddressByUsername(HttpServletRequest http) {
+        String username = (String) http.getAttribute("username");
+        return addressService.findAllByUsername(username);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> changeSelectedAddress(@PathVariable("id") Long addressId, HttpServletRequest http) {
+        String username = (String) http.getAttribute("username");
+        addressService.changeSelectedAddress(addressId, username);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/oheat/user/dto/AddressFindResponse.java
+++ b/src/main/java/com/oheat/user/dto/AddressFindResponse.java
@@ -1,0 +1,32 @@
+package com.oheat.user.dto;
+
+import com.oheat.user.entity.Address;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class AddressFindResponse {
+
+    private final Long id;
+    private final String address;
+    private final String detailAddress;
+    private final Double latitude;
+    private final Double longitude;
+    private final String nickname;
+    private final boolean selected;
+
+    public static AddressFindResponse from(Address address) {
+        return AddressFindResponse.builder()
+            .id(address.getId())
+            .address(address.getAddress())
+            .detailAddress(address.getDetailAddress())
+            .latitude(address.getLatitude())
+            .longitude(address.getLongitude())
+            .nickname(address.getNickname())
+            .selected(address.isSelected())
+            .build();
+    }
+}

--- a/src/main/java/com/oheat/user/dto/AddressSaveRequest.java
+++ b/src/main/java/com/oheat/user/dto/AddressSaveRequest.java
@@ -1,0 +1,32 @@
+package com.oheat.user.dto;
+
+import com.oheat.user.entity.Address;
+import com.oheat.user.entity.UserJpaEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class AddressSaveRequest {
+
+    private final String address;
+    private final String detailAddress;
+    private final Double latitude;
+    private final Double longitude;
+    private final String nickname;
+    private final boolean selected;
+
+    public Address toEntity(UserJpaEntity user) {
+        return Address.builder()
+            .address(address)
+            .detailAddress(detailAddress)
+            .latitude(latitude)
+            .longitude(longitude)
+            .nickname(nickname)
+            .selected(selected)
+            .user(user)
+            .build();
+    }
+}

--- a/src/main/java/com/oheat/user/dto/UserSaveRequest.java
+++ b/src/main/java/com/oheat/user/dto/UserSaveRequest.java
@@ -13,7 +13,6 @@ public class UserSaveRequest {
 
     private final String username;
     private final String password;
-    private final String address;
     private final String phone;
     private final Role role;
 
@@ -21,7 +20,6 @@ public class UserSaveRequest {
         return UserJpaEntity.builder()
             .username(this.username)
             .password(this.password)
-            .address(this.address)
             .phone(this.phone)
             .role(this.role)
             .build();

--- a/src/main/java/com/oheat/user/entity/Address.java
+++ b/src/main/java/com/oheat/user/entity/Address.java
@@ -1,0 +1,68 @@
+package com.oheat.user.entity;
+
+import com.oheat.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(exclude = {"id"}, callSuper = false)
+@Entity
+@Table(name = "address")
+public class Address extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "detail_address")
+    private String detailAddress;
+
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    @Column(name = "nickname")
+    private String nickname;
+
+    @Column(name = "selected")
+    private boolean selected;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserJpaEntity user;
+
+    @Builder
+    public Address(String address, String detailAddress, Double latitude, Double longitude,
+        String nickname, boolean selected, UserJpaEntity user) {
+        this.address = address;
+        this.detailAddress = detailAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.nickname = nickname;
+        this.selected = selected;
+        this.user = user;
+    }
+
+    public void setSelected(boolean selected) {
+        this.selected = selected;
+    }
+}

--- a/src/main/java/com/oheat/user/entity/UserJpaEntity.java
+++ b/src/main/java/com/oheat/user/entity/UserJpaEntity.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(exclude = {"password", "address", "role"}, callSuper = false)
+@EqualsAndHashCode(exclude = {"password", "role"}, callSuper = false)
 @Entity
 @Table(name = "users")
 public class UserJpaEntity extends BaseTimeEntity {
@@ -37,9 +37,6 @@ public class UserJpaEntity extends BaseTimeEntity {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "address", nullable = false)
-    private String address;
-
     @Column(name = "phone", nullable = false)
     private String phone;
 
@@ -51,11 +48,10 @@ public class UserJpaEntity extends BaseTimeEntity {
     private List<CartJpaEntity> carts = new ArrayList<>();
 
     @Builder
-    public UserJpaEntity(String username, String password, String address, String phone,
+    public UserJpaEntity(String username, String password, String phone,
         Role role) {
         this.username = username;
         this.password = password;
-        this.address = address;
         this.phone = phone;
         this.role = role;
     }

--- a/src/main/java/com/oheat/user/exception/AddressNotExistsException.java
+++ b/src/main/java/com/oheat/user/exception/AddressNotExistsException.java
@@ -1,0 +1,15 @@
+package com.oheat.user.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+public class AddressNotExistsException extends RuntimeException {
+
+    private final HttpStatusCode statusCode;
+
+    public AddressNotExistsException(HttpStatusCode statusCode, String message) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+}

--- a/src/main/java/com/oheat/user/repository/AddressJpaRepository.java
+++ b/src/main/java/com/oheat/user/repository/AddressJpaRepository.java
@@ -1,0 +1,18 @@
+package com.oheat.user.repository;
+
+import com.oheat.user.entity.Address;
+import com.oheat.user.entity.UserJpaEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AddressJpaRepository extends JpaRepository<Address, Long> {
+
+    List<Address> findAllByUser(UserJpaEntity user);
+
+    @Modifying
+    @Query("UPDATE Address a SET a.selected = :selected WHERE a.user = :user")
+    void updateSelectedByUser(@Param("user") UserJpaEntity user, @Param("selected") boolean selected);
+}

--- a/src/main/java/com/oheat/user/repository/AddressRepository.java
+++ b/src/main/java/com/oheat/user/repository/AddressRepository.java
@@ -1,0 +1,17 @@
+package com.oheat.user.repository;
+
+import com.oheat.user.entity.Address;
+import com.oheat.user.entity.UserJpaEntity;
+import java.util.List;
+import java.util.Optional;
+
+public interface AddressRepository {
+
+    void save(Address address);
+
+    Optional<Address> findById(Long addressId);
+
+    List<Address> findAllByUser(UserJpaEntity user);
+
+    void updateSelectedByUser(UserJpaEntity user, boolean selected);
+}

--- a/src/main/java/com/oheat/user/repository/AddressRepositoryImpl.java
+++ b/src/main/java/com/oheat/user/repository/AddressRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.oheat.user.repository;
+
+import com.oheat.user.entity.Address;
+import com.oheat.user.entity.UserJpaEntity;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class AddressRepositoryImpl implements AddressRepository {
+
+    private final AddressJpaRepository addressJpaRepository;
+
+    @Override
+    public void save(Address address) {
+        addressJpaRepository.save(address);
+    }
+
+    @Override
+    public Optional<Address> findById(Long addressId) {
+        return addressJpaRepository.findById(addressId);
+    }
+
+    @Override
+    public List<Address> findAllByUser(UserJpaEntity user) {
+        return addressJpaRepository.findAllByUser(user);
+    }
+
+    @Override
+    public void updateSelectedByUser(UserJpaEntity user, boolean selected) {
+        addressJpaRepository.updateSelectedByUser(user, selected);
+    }
+}

--- a/src/main/java/com/oheat/user/service/AddressService.java
+++ b/src/main/java/com/oheat/user/service/AddressService.java
@@ -1,5 +1,6 @@
 package com.oheat.user.service;
 
+import com.oheat.user.dto.AddressFindResponse;
 import com.oheat.user.dto.AddressSaveRequest;
 import com.oheat.user.entity.Address;
 import com.oheat.user.entity.UserJpaEntity;
@@ -27,11 +28,13 @@ public class AddressService {
         addressRepository.save(saveRequest.toEntity(user));
     }
 
-    public List<Address> findAllByUsername(String username) {
+    public List<AddressFindResponse> findAllByUsername(String username) {
         UserJpaEntity user = userRepository.findByUsername(username)
             .orElseThrow(UserNotExistsException::new);
 
-        return addressRepository.findAllByUser(user);
+        return addressRepository.findAllByUser(user)
+            .stream().map(AddressFindResponse::from)
+            .toList();
     }
 
     @Transactional

--- a/src/main/java/com/oheat/user/service/AddressService.java
+++ b/src/main/java/com/oheat/user/service/AddressService.java
@@ -1,0 +1,47 @@
+package com.oheat.user.service;
+
+import com.oheat.user.dto.AddressSaveRequest;
+import com.oheat.user.entity.Address;
+import com.oheat.user.entity.UserJpaEntity;
+import com.oheat.user.exception.AddressNotExistsException;
+import com.oheat.user.exception.UserNotExistsException;
+import com.oheat.user.repository.AddressRepository;
+import com.oheat.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class AddressService {
+
+    private final UserRepository userRepository;
+    private final AddressRepository addressRepository;
+
+    public void registerAddress(AddressSaveRequest saveRequest, String username) {
+        UserJpaEntity user = userRepository.findByUsername(username)
+            .orElseThrow(UserNotExistsException::new);
+
+        addressRepository.save(saveRequest.toEntity(user));
+    }
+
+    public List<Address> findAllByUsername(String username) {
+        UserJpaEntity user = userRepository.findByUsername(username)
+            .orElseThrow(UserNotExistsException::new);
+
+        return addressRepository.findAllByUser(user);
+    }
+
+    @Transactional
+    public void changeSelectedAddress(Long addressId, String username) {
+        UserJpaEntity user = userRepository.findByUsername(username)
+            .orElseThrow(UserNotExistsException::new);
+
+        addressRepository.updateSelectedByUser(user, false);
+        Address address = addressRepository.findById(addressId)
+            .orElseThrow(() -> new AddressNotExistsException(HttpStatus.BAD_REQUEST, "존재하지 않는 주소입니다."));
+        address.setSelected(true);
+    }
+}

--- a/src/test/java/com/oheat/food/fake/MemoryShopRepository.java
+++ b/src/test/java/com/oheat/food/fake/MemoryShopRepository.java
@@ -1,5 +1,6 @@
 package com.oheat.food.fake;
 
+import com.oheat.food.dto.Coordinates;
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.repository.ShopRepository;
@@ -41,6 +42,13 @@ public class MemoryShopRepository implements ShopRepository {
             .filter(shop -> shop.getCategory().equals(category))
             .toList();
         return new PageImpl<>(shopList);
+    }
+
+    @Override
+    public Page<ShopJpaEntity> findByCategoryOrderByDistance(CategoryJpaEntity category, Coordinates coordinates,
+        Pageable pageable) {
+        // Do nothing
+        return null;
     }
 
     @Override

--- a/src/test/java/com/oheat/food/fake/MemoryShopRepository.java
+++ b/src/test/java/com/oheat/food/fake/MemoryShopRepository.java
@@ -4,6 +4,9 @@ import com.oheat.food.dto.Coordinates;
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.repository.ShopRepository;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 @Getter
 public class MemoryShopRepository implements ShopRepository {
 
+    private static final double EARTH_RADIUS_KM = 6371.0;
     private final Map<Long, ShopJpaEntity> shops = new HashMap<>();
     private Long autoId = 1L;
 
@@ -41,18 +45,72 @@ public class MemoryShopRepository implements ShopRepository {
         List<ShopJpaEntity> shopList = shops.values().stream()
             .filter(shop -> shop.getCategory().equals(category))
             .toList();
+
+        if (pageable.getSort().getOrderFor("deliveryFee") != null) {
+            shopList = shopList.stream()
+                .sorted(Comparator.comparing(ShopJpaEntity::getDeliveryFee))
+                .toList();
+        }
+
+        if (pageable.getSort().getOrderFor("minimumOrderAmount") != null) {
+            shopList = shopList.stream()
+                .sorted(Comparator.comparing(ShopJpaEntity::getMinimumOrderAmount))
+                .toList();
+        }
         return new PageImpl<>(shopList);
     }
 
     @Override
     public Page<ShopJpaEntity> findByCategoryOrderByDistance(CategoryJpaEntity category, Coordinates coordinates,
         Pageable pageable) {
-        // Do nothing
-        return null;
+
+        List<ShopJpaEntity> shopList = shops.values().stream()
+            .filter(shop -> shop.getCategory().equals(category))
+            .toList();
+
+        Integer[] index = new Integer[shopList.size()];
+        for (int i = 0; i < index.length; i++) {
+            index[i] = i;
+        }
+
+        // 거리 계산 후, distance[i] 에 저장
+        double[] distance = new double[shopList.size()];
+        for (int i = 0; i < shopList.size(); i++) {
+            double lat1 = coordinates.getLatitude();
+            double lon1 = coordinates.getLongitude();
+            double lat2 = shopList.get(i).getLatitude();
+            double lon2 = shopList.get(i).getLongitude();
+            distance[i] = calculateDistance(lat1, lon1, lat2, lon2);
+        }
+        // distance에 저장된 값을 기준으로 하여 거리순으로 인덱스 정렬
+        Arrays.sort(index, Comparator.comparingInt(i -> (int) (distance[i] * 1000000)));
+
+        // 인덱스 순서에 맞게 매장 순서 재구성
+        List<ShopJpaEntity> result = new ArrayList<>();
+        for (int i = 0; i < index.length; i++) {
+            result.add(shopList.get(index[i]));
+        }
+        return new PageImpl<>(result);
     }
 
     @Override
     public void deleteById(Long shopId) {
         shops.remove(shopId);
+    }
+
+    private static double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double rLat1 = Math.toRadians(lat1);
+        double rLat2 = Math.toRadians(lat2);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(rLat1) * Math.cos(rLat2) *
+                Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return EARTH_RADIUS_KM * c;
     }
 }

--- a/src/test/java/com/oheat/food/jpaTest/MenuGroupRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/MenuGroupRepositoryTest.java
@@ -57,7 +57,8 @@ public class MenuGroupRepositoryTest {
     @DisplayName("해당 매장이 없으면, 새 메뉴 그룹 추가 실패")
     void usingJpa_givenWrongShop_whenRegisterMenuGroup_thenFail() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
 
         categoryJpaRepository.save(category);
 
@@ -77,7 +78,8 @@ public class MenuGroupRepositoryTest {
     @DisplayName("해당 매장이 존재하면, 새 메뉴 그룹 추가 성공")
     void usingJpa_givenShop_whenRegisterMenuGroup_thenSuccess() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
 
         categoryJpaRepository.save(category);
         shopJpaRepository.save(shop);
@@ -92,7 +94,8 @@ public class MenuGroupRepositoryTest {
     @DisplayName("해당 메뉴 그룹이 없으면, 메뉴 그룹에 메뉴 추가 실패")
     void usingJpa_givenWrongMenu_whenAddMenuGroup_thenFail() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         MenuGroupJpaEntity menuGroup = MenuGroupJpaEntity.builder().name("후라이드").shop(shop).build();
         MenuJpaEntity menu = MenuJpaEntity.builder().name("황올").shop(shop).build();
 
@@ -117,7 +120,8 @@ public class MenuGroupRepositoryTest {
     @DisplayName("매장과 메뉴가 존재하면, 메뉴 그룹에 메뉴 추가 성공")
     void usingJpa_givenShopAndMenu_whenAddMenuGroup_thenSuccess() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         MenuGroupJpaEntity menuGroup = MenuGroupJpaEntity.builder().name("후라이드").shop(shop).build();
         MenuJpaEntity menu = MenuJpaEntity.builder().name("황올").shop(shop).build();
 
@@ -136,7 +140,8 @@ public class MenuGroupRepositoryTest {
     @DisplayName("매장에 메뉴 그룹이 2개 있다면, 메뉴 그룹을 전체 조회했을 때 그룹 개수가 2개여야 함")
     void usingJpa_givenTwoMenuGroup_whenFindAllMenuGroup_thenReturnTwoMenuGroup() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         MenuGroupJpaEntity menuGroup1 = MenuGroupJpaEntity.builder().name("후라이").shop(shop).build();
         MenuGroupJpaEntity menuGroup2 = MenuGroupJpaEntity.builder().name("양념").shop(shop).build();
 
@@ -156,7 +161,8 @@ public class MenuGroupRepositoryTest {
     @DisplayName("후라이드 메뉴 그룹에 치킨 메뉴가 2개 있다면, 메뉴 그룹을 통해 메뉴 2개가 조회되어야 함")
     void usingJpa_givenMenuGroupWithTwoMenu_whenFindMenuInMenuGroup_thenReturnTwoMenu() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         MenuGroupJpaEntity menuGroup = MenuGroupJpaEntity.builder().name("후라이").shop(shop).build();
         MenuJpaEntity menu1 = MenuJpaEntity.builder().name("황올").shop(shop).build();
         MenuJpaEntity menu2 = MenuJpaEntity.builder().name("닭다리").shop(shop).build();

--- a/src/test/java/com/oheat/food/jpaTest/MenuRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/MenuRepositoryTest.java
@@ -70,9 +70,10 @@ public class MenuRepositoryTest {
     @DisplayName("shopId에 해당하는 매장이 있으면, 메뉴 저장 성공")
     void usingJpa_givenMenuWithShopId_whenAddNewMenu_thenSuccess() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         categoryJpaRepository.save(category);
-        ShopJpaEntity shop = shopJpaRepository.save(
-            ShopJpaEntity.builder().name("bbq").category(category).build());
+        shopJpaRepository.save(shop);
 
         Assertions.assertDoesNotThrow(() -> {
             menuJpaRepository.save(MenuJpaEntity.builder().name("황올").shop(shop).build());
@@ -83,9 +84,10 @@ public class MenuRepositoryTest {
     @DisplayName("하나의 매장에 3개 메뉴를 저장한 뒤, 매장 엔티티를 조회하면 menuList의 size는 3이어야 함")
     void usingJpa_givenThreeMenu_whenAddNewMenu_thenListSizeThree() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         categoryJpaRepository.save(category);
-        ShopJpaEntity shop = shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq").category(category).build());
+        shopJpaRepository.save(shop);
 
         for (int i = 0; i < 3; i++) {
             menuJpaRepository.save(MenuJpaEntity.builder()
@@ -104,7 +106,8 @@ public class MenuRepositoryTest {
     @DisplayName("카테고리, 매장, 메뉴, 옵션 그룹, 옵션을 차례로 알맞게 저장하면 모두 저장 성공")
     void givenShopAndMenuAndOptionGroupAndOption_whenAddNewMenu_thenSuccess() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         MenuJpaEntity menu = MenuJpaEntity.builder().name("황올").shop(shop).build();
         OptionGroupJpaEntity optionGroup = OptionGroupJpaEntity.builder()
             .name("부분육 선택").menu(menu).build();
@@ -135,7 +138,8 @@ public class MenuRepositoryTest {
     @DisplayName("각각 옵션이 2개인 옵션 그룹을 2개 가진 메뉴를 조회하면 총 옵션 개수는 4개임")
     void givenTwoOptionGroupsWithTwoOptions_whenFindMenu_thenTotalOptionFour() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         MenuJpaEntity menu = MenuJpaEntity.builder().name("황올").shop(shop).build();
         OptionGroupJpaEntity optionGroup1 = OptionGroupJpaEntity.builder()
             .name("부분육 선택").menu(menu).build();
@@ -177,7 +181,8 @@ public class MenuRepositoryTest {
     @DisplayName("메뉴를 삭제하면, 옵션 그룹과 옵션도 삭제됨")
     void whenDeleteMenu_thenDeleteOptionGroupAndOption() {
         CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
-        ShopJpaEntity shop = ShopJpaEntity.builder().name("bbq").category(category).build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
         MenuJpaEntity menu = MenuJpaEntity.builder().name("황올").shop(shop).build();
         OptionGroupJpaEntity optionGroup = OptionGroupJpaEntity.builder()
             .name("부분육 선택").menu(menu).build();

--- a/src/test/java/com/oheat/food/jpaTest/ShopRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/ShopRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.oheat.common.TestConfig;
+import com.oheat.food.dto.Coordinates;
 import com.oheat.food.entity.CategoryJpaEntity;
 import com.oheat.food.entity.ShopJpaEntity;
 import com.oheat.food.repository.CategoryJpaRepository;
@@ -116,7 +117,7 @@ public class ShopRepositoryTest {
         }
 
         PageRequest page0 = PageRequest.of(0, 5);
-        Page<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0);
+        Page<ShopJpaEntity> result = shopJpaRepository.findByCategory(category, page0);
 
         assertThat(result.getContent().size()).isEqualTo(3);
     }
@@ -139,9 +140,9 @@ public class ShopRepositoryTest {
         PageRequest page0 = PageRequest.of(0, 5);
         PageRequest page1 = PageRequest.of(1, 5);
         Page<ShopJpaEntity> result1 = shopJpaRepository
-            .findShopByCategory(category, page0);
+            .findByCategory(category, page0);
         Page<ShopJpaEntity> result2 = shopJpaRepository
-            .findShopByCategory(category, page1);
+            .findByCategory(category, page1);
 
         assertThat(result1.getContent().size()).isEqualTo(5);
         assertThat(result2.getContent().size()).isEqualTo(2);
@@ -175,7 +176,7 @@ public class ShopRepositoryTest {
             .build());
 
         PageRequest page0 = PageRequest.of(0, 5, Sort.by("id").descending());
-        List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
+        List<ShopJpaEntity> result = shopJpaRepository.findByCategory(category, page0)
             .getContent();
 
         assertThat(result.get(0).getId()).isEqualTo(3L);
@@ -212,7 +213,7 @@ public class ShopRepositoryTest {
             .build());
 
         PageRequest page0 = PageRequest.of(0, 5, Sort.by("deliveryFee").ascending());
-        List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
+        List<ShopJpaEntity> result = shopJpaRepository.findByCategory(category, page0)
             .getContent();
 
         assertThat(result.get(0).getId()).isEqualTo(2L);
@@ -249,7 +250,7 @@ public class ShopRepositoryTest {
             .build());
 
         PageRequest page0 = PageRequest.of(0, 5, Sort.by("minimumOrderAmount").ascending());
-        List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
+        List<ShopJpaEntity> result = shopJpaRepository.findByCategory(category, page0)
             .getContent();
 
         assertThat(result.get(0).getId()).isEqualTo(2L);
@@ -287,7 +288,7 @@ public class ShopRepositoryTest {
 
         PageRequest page0 = PageRequest.of(0, 5, Sort.by("minimumOrderAmount").ascending()
             .and(Sort.by("id").descending()));
-        List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
+        List<ShopJpaEntity> result = shopJpaRepository.findByCategory(category, page0)
             .getContent();
 
         assertThat(result.get(0).getId()).isEqualTo(3L);
@@ -312,16 +313,32 @@ public class ShopRepositoryTest {
             .name("bbq 2호점")
             .category(category)
             .minimumOrderAmount(3000)
-            .latitude(37.0)
-            .longitude(127.0)
+            .latitude(37.1)
+            .longitude(127.1)
             .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
             .name("bbq 3호점")
             .category(category)
             .minimumOrderAmount(1000)
-            .latitude(37.0)
-            .longitude(127.0)
+            .latitude(37.2)
+            .longitude(127.2)
             .build());
+
+        Coordinates coordinates = Coordinates.builder()
+            .latitude(37.3)
+            .longitude(127.3)
+            .build();
+
+        PageRequest distanceOrder = PageRequest.of(0, 5, Sort.by("distance")
+            .and(Sort.by("id").descending()));
+
+        List<ShopJpaEntity> result = shopJpaRepository.findByCategoryOrderByDistance(category, coordinates,
+                distanceOrder)
+            .getContent();
+
+        assertThat(result.get(0).getId()).isEqualTo(3L);
+        assertThat(result.get(1).getId()).isEqualTo(2L);
+        assertThat(result.get(2).getId()).isEqualTo(1L);
     }
 
     @Disabled

--- a/src/test/java/com/oheat/food/jpaTest/ShopRepositoryTest.java
+++ b/src/test/java/com/oheat/food/jpaTest/ShopRepositoryTest.java
@@ -60,46 +60,41 @@ public class ShopRepositoryTest {
     @Test
     @DisplayName("이름이 중복되지 않으면, 매장 등록 성공")
     void shopNameNotDuplicate_thenSuccess() {
-        categoryJpaRepository.save(
-            CategoryJpaEntity.builder()
-                .name("치킨")
-                .build()
-        );
-        CategoryJpaEntity category = categoryJpaRepository.findByName("치킨").get();
+        CategoryJpaEntity category = CategoryJpaEntity.builder()
+            .name("치킨")
+            .build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq").category(category).latitude(37.0).longitude(127.0).build();
 
-        assertDoesNotThrow(() -> {
-            shopJpaRepository.save(
-                ShopJpaEntity.builder()
-                    .name("bbq")
-                    .category(category)
-                    .minimumOrderAmount(14_000)
-                    .build());
-        });
+        categoryJpaRepository.save(category);
+
+        assertDoesNotThrow(() -> shopJpaRepository.save(shop));
     }
 
     @Test
     @DisplayName("이름이 중복되면, 매장 등록 실패")
     void shopNameDuplicate_thenFail() {
-        categoryJpaRepository.save(
-            CategoryJpaEntity.builder()
-                .name("치킨")
-                .build()
-        );
-        CategoryJpaEntity category = categoryJpaRepository.findByName("치킨").get();
+        CategoryJpaEntity category = CategoryJpaEntity.builder()
+            .name("치킨")
+            .build();
+        ShopJpaEntity shop = ShopJpaEntity.builder()
+            .name("bbq")
+            .category(category)
+            .minimumOrderAmount(14_000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build();
 
-        shopJpaRepository.save(
-            ShopJpaEntity.builder()
-                .name("bbq")
-                .category(category)
-                .minimumOrderAmount(14_000)
-                .build());
+        categoryJpaRepository.save(category);
+        shopJpaRepository.save(shop);
 
         assertThrows(DataIntegrityViolationException.class, () -> {
             shopJpaRepository.save(
                 ShopJpaEntity.builder()
                     .name("bbq")
                     .category(category)
-                    .minimumOrderAmount(14_000)
+                    .latitude(37.0)
+                    .longitude(127.0)
                     .build());
         });
         entityManager.clear();
@@ -113,7 +108,11 @@ public class ShopRepositoryTest {
 
         for (int i = 0; i < 3; i++) {
             shopJpaRepository.save(ShopJpaEntity.builder()
-                .name("bbq " + i + "호점").category(category).build());
+                .name("bbq " + i + "호점")
+                .category(category)
+                .latitude(37.0)
+                .longitude(127.0)
+                .build());
         }
 
         PageRequest page0 = PageRequest.of(0, 5);
@@ -130,7 +129,11 @@ public class ShopRepositoryTest {
 
         for (int i = 0; i < 7; i++) {
             shopJpaRepository.save(ShopJpaEntity.builder()
-                .name("bbq " + i + "호점").category(category).build());
+                .name("bbq " + i + "호점")
+                .category(category)
+                .latitude(37.0)
+                .longitude(127.0)
+                .build());
         }
 
         PageRequest page0 = PageRequest.of(0, 5);
@@ -153,11 +156,23 @@ public class ShopRepositoryTest {
         categoryJpaRepository.save(category);
 
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 1호점").category(category).build());
+            .name("bbq 1호점")
+            .category(category)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 2호점").category(category).build());
+            .name("bbq 2호점")
+            .category(category)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 3호점").category(category).build());
+            .name("bbq 3호점")
+            .category(category)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
 
         PageRequest page0 = PageRequest.of(0, 5, Sort.by("id").descending());
         List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
@@ -175,11 +190,26 @@ public class ShopRepositoryTest {
         categoryJpaRepository.save(category);
 
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 1호점").category(category).deliveryFee(2000).build());
+            .name("bbq 1호점")
+            .category(category)
+            .deliveryFee(2000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 2호점").category(category).deliveryFee(1000).build());
+            .name("bbq 2호점")
+            .category(category)
+            .deliveryFee(1000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 3호점").category(category).deliveryFee(5000).build());
+            .name("bbq 3호점")
+            .category(category)
+            .deliveryFee(5000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
 
         PageRequest page0 = PageRequest.of(0, 5, Sort.by("deliveryFee").ascending());
         List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
@@ -197,11 +227,26 @@ public class ShopRepositoryTest {
         categoryJpaRepository.save(category);
 
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 1호점").category(category).minimumOrderAmount(2000).build());
+            .name("bbq 1호점")
+            .category(category)
+            .minimumOrderAmount(2000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 2호점").category(category).minimumOrderAmount(1000).build());
+            .name("bbq 2호점")
+            .category(category)
+            .minimumOrderAmount(1000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 3호점").category(category).minimumOrderAmount(5000).build());
+            .name("bbq 3호점")
+            .category(category)
+            .minimumOrderAmount(5000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
 
         PageRequest page0 = PageRequest.of(0, 5, Sort.by("minimumOrderAmount").ascending());
         List<ShopJpaEntity> result = shopJpaRepository.findShopByCategory(category, page0)
@@ -219,11 +264,26 @@ public class ShopRepositoryTest {
         categoryJpaRepository.save(category);
 
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 1호점").category(category).minimumOrderAmount(1000).build());
+            .name("bbq 1호점")
+            .category(category)
+            .minimumOrderAmount(1000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 2호점").category(category).minimumOrderAmount(3000).build());
+            .name("bbq 2호점")
+            .category(category)
+            .minimumOrderAmount(3000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
         shopJpaRepository.save(ShopJpaEntity.builder()
-            .name("bbq 3호점").category(category).minimumOrderAmount(1000).build());
+            .name("bbq 3호점")
+            .category(category)
+            .minimumOrderAmount(1000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
 
         PageRequest page0 = PageRequest.of(0, 5, Sort.by("minimumOrderAmount").ascending()
             .and(Sort.by("id").descending()));
@@ -235,11 +295,33 @@ public class ShopRepositoryTest {
         assertThat(result.get(2).getId()).isEqualTo(2L);
     }
 
-    @Disabled
     @Test
     @DisplayName("카테고리로 매장 목록 조회 시 정렬 기준이 가까운 순이면, 내 위치에서의 거리 오름차순으로 조회")
     void whenSortByNearestOrder_thenDistanceInMyLocationAscendingOrder() {
+        CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
+        categoryJpaRepository.save(category);
 
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 1호점")
+            .category(category)
+            .minimumOrderAmount(1000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 2호점")
+            .category(category)
+            .minimumOrderAmount(3000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
+        shopJpaRepository.save(ShopJpaEntity.builder()
+            .name("bbq 3호점")
+            .category(category)
+            .minimumOrderAmount(1000)
+            .latitude(37.0)
+            .longitude(127.0)
+            .build());
     }
 
     @Disabled

--- a/src/test/java/com/oheat/food/serviceTest/ShopServiceTest.java
+++ b/src/test/java/com/oheat/food/serviceTest/ShopServiceTest.java
@@ -3,6 +3,7 @@ package com.oheat.food.serviceTest;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.oheat.food.dto.ShopFindResponse;
 import com.oheat.food.dto.ShopSaveRequest;
 import com.oheat.food.dto.ShopUpdateRequest;
 import com.oheat.food.entity.CategoryJpaEntity;
@@ -14,7 +15,6 @@ import com.oheat.food.fake.MemoryCategoryRepository;
 import com.oheat.food.fake.MemoryShopRepository;
 import com.oheat.food.repository.CategoryRepository;
 import com.oheat.food.repository.ShopRepository;
-import com.oheat.food.service.CategoryService;
 import com.oheat.food.service.ShopService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,14 +26,12 @@ import org.springframework.data.domain.Page;
 public class ShopServiceTest {
 
     private ShopService shopService;
-    private CategoryService categoryService;
     private final ShopRepository memoryShopRepository = new MemoryShopRepository();
     private final CategoryRepository memoryCategoryRepository = new MemoryCategoryRepository();
 
     @BeforeEach
     void setUp() {
         shopService = new ShopService(memoryShopRepository, memoryCategoryRepository);
-        categoryService = new CategoryService(memoryCategoryRepository);
     }
 
     @Test
@@ -112,7 +110,7 @@ public class ShopServiceTest {
                 .build());
         }
 
-        Page<ShopJpaEntity> result = shopService.findShopByCategory("치킨", null);
+        Page<ShopFindResponse> result = shopService.findShopByCategory("치킨", null);
 
         Assertions.assertThat(result.getContent().size()).isEqualTo(3);
     }

--- a/src/test/java/com/oheat/food/serviceTest/ShopServiceTest.java
+++ b/src/test/java/com/oheat/food/serviceTest/ShopServiceTest.java
@@ -17,6 +17,7 @@ import com.oheat.food.fake.MemoryShopRepository;
 import com.oheat.food.repository.CategoryRepository;
 import com.oheat.food.repository.ShopRepository;
 import com.oheat.food.service.ShopService;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -121,6 +122,102 @@ public class ShopServiceTest {
         Page<ShopFindResponse> result = shopService.findShopByCategory(findReq, pageable);
 
         Assertions.assertThat(result.getContent().size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("Pageable 정렬 특성이 최소주문금액 낮은 순이면, 최소주문금액 오름차순으로 매장이 조회됨")
+    void whenFindShopByCategoryOrderByMiniMumOrderAmount_thenReturnMinimumOrderAmountAscendingOrder() {
+        CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
+        memoryCategoryRepository.save(category);
+
+        for (int i = 0; i < 3; i++) {
+            memoryShopRepository.save(ShopJpaEntity.builder()
+                .name("bbq " + i + "호점")
+                .latitude(37.0 + 0.1 * i)
+                .longitude(127.0 + 0.1 * i)
+                .deliveryFee(10000 - 1000 * i)
+                .minimumOrderAmount(10000 - 1000 * i)
+                .category(category)
+                .build());
+        }
+
+        ShopFindRequest findReq = ShopFindRequest.builder()
+            .categoryName("치킨")
+            .latitude(37.9)
+            .longitude(127.9)
+            .build();
+
+        PageRequest pageable = PageRequest.of(0, 5, Sort.by("minimumOrderAmount").ascending());
+
+        List<ShopFindResponse> result = shopService.findShopByCategory(findReq, pageable).getContent();
+
+        Assertions.assertThat(result.get(0).getName()).isEqualTo("bbq 2호점");
+        Assertions.assertThat(result.get(1).getName()).isEqualTo("bbq 1호점");
+        Assertions.assertThat(result.get(2).getName()).isEqualTo("bbq 0호점");
+    }
+
+    @Test
+    @DisplayName("Pageable 정렬 특성이 배달팁 낮은 순이면, 배달팁 오름차순으로 매장이 조회됨")
+    void whenFindShopByCategoryOrderByDeliveryFee_thenReturnDeliveryFeeAscendingOrder() {
+        CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
+        memoryCategoryRepository.save(category);
+
+        for (int i = 0; i < 3; i++) {
+            memoryShopRepository.save(ShopJpaEntity.builder()
+                .name("bbq " + i + "호점")
+                .latitude(37.0 + 0.1 * i)
+                .longitude(127.0 + 0.1 * i)
+                .deliveryFee(10000 - 1000 * i)
+                .minimumOrderAmount(10000 - 1000 * i)
+                .category(category)
+                .build());
+        }
+
+        ShopFindRequest findReq = ShopFindRequest.builder()
+            .categoryName("치킨")
+            .latitude(37.9)
+            .longitude(127.9)
+            .build();
+
+        PageRequest pageable = PageRequest.of(0, 5, Sort.by("deliveryFee").ascending());
+
+        List<ShopFindResponse> result = shopService.findShopByCategory(findReq, pageable).getContent();
+
+        Assertions.assertThat(result.get(0).getName()).isEqualTo("bbq 2호점");
+        Assertions.assertThat(result.get(1).getName()).isEqualTo("bbq 1호점");
+        Assertions.assertThat(result.get(2).getName()).isEqualTo("bbq 0호점");
+    }
+
+    @Test
+    @DisplayName("Pageable 정렬 기준이 distance이면, 가까운 거리순으로 매장이 조회됨.")
+    void whenFindShopByCategoryOrderByDistance_thenReturnCloseDistanceOrder() {
+        CategoryJpaEntity category = CategoryJpaEntity.builder().name("치킨").build();
+        memoryCategoryRepository.save(category);
+
+        for (int i = 0; i < 3; i++) {
+            memoryShopRepository.save(ShopJpaEntity.builder()
+                .name("bbq " + i + "호점")
+                .latitude(37.0 + 0.1 * i)
+                .longitude(127.0 + 0.1 * i)
+                .deliveryFee(10000 - 1000 * i)
+                .minimumOrderAmount(10000 - 1000 * i)
+                .category(category)
+                .build());
+        }
+
+        ShopFindRequest findReq = ShopFindRequest.builder()
+            .categoryName("치킨")
+            .latitude(37.9)
+            .longitude(127.9)
+            .build();
+
+        PageRequest pageable = PageRequest.of(0, 5, Sort.by("distance").ascending());
+
+        List<ShopFindResponse> result = shopService.findShopByCategory(findReq, pageable).getContent();
+
+        Assertions.assertThat(result.get(0).getName()).isEqualTo("bbq 2호점");
+        Assertions.assertThat(result.get(1).getName()).isEqualTo("bbq 1호점");
+        Assertions.assertThat(result.get(2).getName()).isEqualTo("bbq 0호점");
     }
 
     @Disabled

--- a/src/test/java/com/oheat/food/serviceTest/ShopServiceTest.java
+++ b/src/test/java/com/oheat/food/serviceTest/ShopServiceTest.java
@@ -3,6 +3,7 @@ package com.oheat.food.serviceTest;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.oheat.food.dto.ShopFindRequest;
 import com.oheat.food.dto.ShopFindResponse;
 import com.oheat.food.dto.ShopSaveRequest;
 import com.oheat.food.dto.ShopUpdateRequest;
@@ -22,6 +23,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 public class ShopServiceTest {
 
@@ -110,7 +113,12 @@ public class ShopServiceTest {
                 .build());
         }
 
-        Page<ShopFindResponse> result = shopService.findShopByCategory("치킨", null);
+        ShopFindRequest findReq = ShopFindRequest.builder()
+            .categoryName("치킨")
+            .build();
+
+        PageRequest pageable = PageRequest.of(0, 5, Sort.by("id").descending());
+        Page<ShopFindResponse> result = shopService.findShopByCategory(findReq, pageable);
 
         Assertions.assertThat(result.getContent().size()).isEqualTo(3);
     }

--- a/src/test/java/com/oheat/order/OrderIntegrationTest.java
+++ b/src/test/java/com/oheat/order/OrderIntegrationTest.java
@@ -240,6 +240,7 @@ public class OrderIntegrationTest {
                 .deliveryFee(0)
                 .payMethod(PayMethod.TOSS)
                 .discount(0)
+                .address("서울특별시")
                 .build();
 
             entityManager.flush();
@@ -275,7 +276,6 @@ public class OrderIntegrationTest {
         UserJpaEntity user = UserJpaEntity.builder()
             .username("username")
             .password("pw")
-            .address("서울특별시")
             .phone("010-1234-1234")
             .role(Role.CUSTOMER)
             .build();

--- a/src/test/java/com/oheat/order/OrderIntegrationTest.java
+++ b/src/test/java/com/oheat/order/OrderIntegrationTest.java
@@ -287,6 +287,8 @@ public class OrderIntegrationTest {
             .minimumOrderAmount(10000)
             .deliveryFee(2000)
             .category(category)
+            .latitude(37.0)
+            .longitude(127.0)
             .build();
         MenuJpaEntity menu = MenuJpaEntity.builder()
             .name("황올")

--- a/src/test/java/com/oheat/order/OrderServiceTest.java
+++ b/src/test/java/com/oheat/order/OrderServiceTest.java
@@ -218,6 +218,7 @@ public class OrderServiceTest {
             .deliveryFee(3000)
             .discount(0)
             .payMethod(PayMethod.TOSS)
+            .address("서울특별시")
             .build();
 
         Assertions.assertDoesNotThrow(() -> {
@@ -509,7 +510,6 @@ public class OrderServiceTest {
         List<OrderOptionGroup> orderOptionGroups = orderMenus.get(0).getOrderOptionGroups();
         List<OrderOption> orderOptions = orderOptionGroups.get(0).getOrderOptions();
 
-        assertThat(order.getAddress()).isEqualTo("서울특별시");
         assertThat(order.getPhone()).isEqualTo("010-1234-1234");
         assertThat(order.getPayMethod()).isEqualTo(PayMethod.TOSS);
         assertThat(orderMenus.size()).isEqualTo(1);
@@ -583,7 +583,7 @@ public class OrderServiceTest {
 
     private UserJpaEntity generateUserWithCarts() {
         UserJpaEntity user = UserJpaEntity.builder()
-            .username("user").address("서울특별시").phone("010-1234-1234").build();
+            .username("user").phone("010-1234-1234").build();
         ShopJpaEntity shop = ShopJpaEntity.builder()
             .name("bbq").build();
         MenuJpaEntity menu = MenuJpaEntity.builder()

--- a/src/test/java/com/oheat/user/AddressServiceTest.java
+++ b/src/test/java/com/oheat/user/AddressServiceTest.java
@@ -3,6 +3,7 @@ package com.oheat.user;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.oheat.user.constant.Role;
+import com.oheat.user.dto.AddressFindResponse;
 import com.oheat.user.dto.AddressSaveRequest;
 import com.oheat.user.entity.Address;
 import com.oheat.user.entity.UserJpaEntity;
@@ -67,7 +68,7 @@ public class AddressServiceTest {
         addressService.registerAddress(addressSaveRequest, "sgoh");
         addressService.registerAddress(addressSaveRequest, "sgoh");
 
-        List<Address> result = addressService.findAllByUsername("sgoh");
+        List<AddressFindResponse> result = addressService.findAllByUsername("sgoh");
         assertThat(result.size()).isEqualTo(2);
     }
 
@@ -93,7 +94,7 @@ public class AddressServiceTest {
 
         addressService.changeSelectedAddress(2L, "sgoh");
 
-        List<Address> result = addressService.findAllByUsername("sgoh");
+        List<AddressFindResponse> result = addressService.findAllByUsername("sgoh");
         assertThat(result.get(0).isSelected()).isFalse();
         assertThat(result.get(1).isSelected()).isTrue();
     }

--- a/src/test/java/com/oheat/user/AddressServiceTest.java
+++ b/src/test/java/com/oheat/user/AddressServiceTest.java
@@ -1,0 +1,100 @@
+package com.oheat.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.oheat.user.constant.Role;
+import com.oheat.user.dto.AddressSaveRequest;
+import com.oheat.user.entity.Address;
+import com.oheat.user.entity.UserJpaEntity;
+import com.oheat.user.repository.AddressRepository;
+import com.oheat.user.repository.UserRepository;
+import com.oheat.user.service.AddressService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AddressServiceTest {
+
+    private final UserRepository memoryUserRepository = new MemoryUserRepository();
+    private final AddressRepository memoryAddressRepository = new MemoryAddressRepository();
+    private AddressService addressService;
+
+    @BeforeEach
+    void setUp() {
+        addressService = new AddressService(memoryUserRepository, memoryAddressRepository);
+    }
+
+    @Test
+    @DisplayName("배달시킬 주소를 새로 등록한다")
+    void whenRegisterAddress_thenSuccess() {
+        UserJpaEntity user = UserJpaEntity.builder()
+            .username("sgoh")
+            .password("pw")
+            .role(Role.ADMIN)
+            .build();
+        memoryUserRepository.save(user);
+
+        AddressSaveRequest addressSaveRequest = AddressSaveRequest.builder()
+            .address("서울특별시 광진구")
+            .detailAddress("000동 000호")
+            .latitude(37.547889)
+            .longitude(126.997128)
+            .build();
+        addressService.registerAddress(addressSaveRequest, "sgoh");
+
+        Optional<Address> result = memoryAddressRepository.findById(1L);
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    @DisplayName("주소지 목록을 조회한다")
+    void whenFindAllAddress_thenReturnAddressList() {
+        UserJpaEntity user = UserJpaEntity.builder()
+            .username("sgoh")
+            .password("pw")
+            .role(Role.ADMIN)
+            .build();
+        memoryUserRepository.save(user);
+
+        AddressSaveRequest addressSaveRequest = AddressSaveRequest.builder()
+            .address("서울특별시 광진구")
+            .detailAddress("000동 000호")
+            .latitude(37.547889)
+            .longitude(126.997128)
+            .build();
+        addressService.registerAddress(addressSaveRequest, "sgoh");
+        addressService.registerAddress(addressSaveRequest, "sgoh");
+
+        List<Address> result = addressService.findAllByUsername("sgoh");
+        assertThat(result.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("기존에 선택된 주소를 선택 해제하고, 요청된 주소를 현재 주소로 선택한다.")
+    void whenChangeSelectedAddress_thenDeselectAllAddressAndSelectRequestAddress() {
+        UserJpaEntity user = UserJpaEntity.builder()
+            .username("sgoh")
+            .password("pw")
+            .role(Role.ADMIN)
+            .build();
+        memoryUserRepository.save(user);
+
+        AddressSaveRequest addressSaveRequest = AddressSaveRequest.builder()
+            .address("서울특별시 광진구")
+            .detailAddress("000동 000호")
+            .latitude(37.547889)
+            .longitude(126.997128)
+            .selected(true)
+            .build();
+        addressService.registerAddress(addressSaveRequest, "sgoh");
+        addressService.registerAddress(addressSaveRequest, "sgoh");
+
+        addressService.changeSelectedAddress(2L, "sgoh");
+
+        List<Address> result = addressService.findAllByUsername("sgoh");
+        assertThat(result.get(0).isSelected()).isFalse();
+        assertThat(result.get(1).isSelected()).isTrue();
+    }
+}

--- a/src/test/java/com/oheat/user/CartIntegrationTest.java
+++ b/src/test/java/com/oheat/user/CartIntegrationTest.java
@@ -81,7 +81,6 @@ public class CartIntegrationTest {
         UserJpaEntity user = UserJpaEntity.builder()
             .username("username")
             .password("pw")
-            .address("서울특별시")
             .phone("010-1234-1234")
             .role(Role.CUSTOMER)
             .build();
@@ -205,7 +204,6 @@ public class CartIntegrationTest {
         UserJpaEntity user = UserJpaEntity.builder()
             .username("username")
             .password("pw")
-            .address("서울특별시")
             .phone("010-1234-1234")
             .role(Role.CUSTOMER)
             .build();

--- a/src/test/java/com/oheat/user/CartIntegrationTest.java
+++ b/src/test/java/com/oheat/user/CartIntegrationTest.java
@@ -92,6 +92,8 @@ public class CartIntegrationTest {
             .minimumOrderAmount(10000)
             .deliveryFee(2000)
             .category(category)
+            .latitude(37.0)
+            .longitude(127.0)
             .build();
         MenuJpaEntity menu = MenuJpaEntity.builder()
             .name("황올")
@@ -215,6 +217,8 @@ public class CartIntegrationTest {
             .minimumOrderAmount(10000)
             .deliveryFee(2000)
             .category(category)
+            .latitude(37.0)
+            .longitude(127.0)
             .build();
         MenuJpaEntity menu = MenuJpaEntity.builder()
             .name("황올")

--- a/src/test/java/com/oheat/user/MemoryAddressRepository.java
+++ b/src/test/java/com/oheat/user/MemoryAddressRepository.java
@@ -1,0 +1,39 @@
+package com.oheat.user;
+
+import com.oheat.user.entity.Address;
+import com.oheat.user.entity.UserJpaEntity;
+import com.oheat.user.repository.AddressRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class MemoryAddressRepository implements AddressRepository {
+
+    private final Map<Long, Address> addressMap = new HashMap<>();
+    private Long autoId = 1L;
+
+    @Override
+    public void save(Address address) {
+        addressMap.put(autoId++, address);
+    }
+
+    @Override
+    public Optional<Address> findById(Long addressId) {
+        return Optional.ofNullable(addressMap.get(addressId));
+    }
+
+    @Override
+    public List<Address> findAllByUser(UserJpaEntity user) {
+        return addressMap.values().stream()
+            .filter(address -> address.getUser().getUsername().equals(user.getUsername()))
+            .toList();
+    }
+
+    @Override
+    public void updateSelectedByUser(UserJpaEntity user, boolean selected) {
+        for (Address address : addressMap.values()) {
+            address.setSelected(selected);
+        }
+    }
+}

--- a/src/test/java/com/oheat/user/UserServiceTest.java
+++ b/src/test/java/com/oheat/user/UserServiceTest.java
@@ -12,7 +12,6 @@ import com.oheat.user.repository.UserRepository;
 import com.oheat.user.service.UserService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,6 @@ public class UserServiceTest {
         UserSaveRequest saveRequest = UserSaveRequest.builder()
             .username("sgoh")
             .password("pw")
-            .address("서울특별시 광진구")
             .role(Role.ADMIN)
             .build();
 
@@ -48,7 +46,6 @@ public class UserServiceTest {
         UserSaveRequest saveRequest = UserSaveRequest.builder()
             .username("sgoh")
             .password("pw")
-            .address("서울특별시 광진구")
             .role(Role.ADMIN)
             .build();
 
@@ -73,7 +70,6 @@ public class UserServiceTest {
         UserSaveRequest saveRequest = UserSaveRequest.builder()
             .username("sgoh")
             .password("pw")
-            .address("서울특별시 광진구")
             .role(Role.ADMIN)
             .build();
         LoginRequest loginRequest = LoginRequest.builder().username("sgoh").password("pw").build();
@@ -90,7 +86,6 @@ public class UserServiceTest {
         UserSaveRequest saveRequest = UserSaveRequest.builder()
             .username("sgoh")
             .password("pw")
-            .address("서울특별시 광진구")
             .role(Role.ADMIN)
             .build();
         LoginRequest loginRequest = LoginRequest.builder().username("sgoh").password("pw").build();
@@ -103,33 +98,5 @@ public class UserServiceTest {
 
         assertThat(username).isEqualTo("sgoh");
         assertThat(userRole).isEqualTo(Role.ADMIN);
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("배달시킬 주소를 새로 등록한다")
-    void whenRegisterAddress_thenSuccess() {
-
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("배달 주소 목록을 조회한다")
-    void whenFindAllAddress_thenReturnAddressList() {
-
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("배달 주소 목록 중, 현재 선택된 배달 주소를 조회한다")
-    void whenFindSelectedAddress_thenReturnSelectedAddress() {
-
-    }
-
-    @Disabled
-    @Test
-    @DisplayName("배달 주소 목록 중, 기존에 등록했던 다른 주소를 선택하여 주소 설정 값을 변경한다")
-    void whenChangeSelectedAddress_thenSuccess() {
-
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- Address 엔티티 생성 후, 사용자 주소 목록 기능 구현
- 매장 테이블에 좌표값 추가
- 하버사인 공식으로 가까운 거리순 조회 기능 구현

## 🔧 앞으로의 과제

- 지역 테이블 생성 및 연결

## ✅ 해결 이슈

- resolved #34 
